### PR TITLE
Filter message history to include only the last 7 days

### DIFF
--- a/services/chat.js
+++ b/services/chat.js
@@ -86,6 +86,7 @@ async function sendMessageHistory(ws) {
         const result = await pool.query(`
             SELECT username, content, timestamp, message_type, message_color, client_uuid
             FROM website.messages 
+            WHERE timestamp >= CURRENT_TIMESTAMP - INTERVAL '7 days'
             ORDER BY timestamp DESC 
             LIMIT 50
         `);


### PR DESCRIPTION
This pull request includes a change to the `services/chat.js` file to improve the querying of message history in the chat service.

* [`services/chat.js`](diffhunk://#diff-856c076946e7166e615707b76439fed6f3d0007b61d3ce78c904ab1e89fee59eR89): Modified the `sendMessageHistory` function to include a filter that retrieves messages from the past 7 days.