### PR TITLE
Refactor allowed services list

### DIFF
--- a/config/service_monitoring.js
+++ b/config/service_monitoring.js
@@ -1,7 +1,7 @@
 // config/service_monitoring.js
 const ALLOWED_SERVICES = [
-  'dane.gg (Website)',
-  'dane.lol (Website)',
+  'dane.gg',
+  'dane.lol',
   'Dane\'s Dungeon Bot'
 ];
 


### PR DESCRIPTION
This pull request includes a small change to the `config/service_monitoring.js` file. The change involves updating the `ALLOWED_SERVICES` array to remove the "(Website)" descriptor from the `dane.gg` and `dane.lol` entries.

* [`config/service_monitoring.js`](diffhunk://#diff-5f528d77c2868ad4d5a9ae208013dd43d4044c14ba25a4e422a2514ae3527dccL3-R4): Updated `ALLOWED_SERVICES` array to remove "(Website)" descriptor from `dane.gg` and `dane.lol` entries.