### PR TITLE
Refactor status item data attributes for consistency

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -340,11 +340,11 @@
                 <div class="card status mobile-order-5">
                     <h3>Status</h3>
                     <div class="status-items">
-                        <div class="status-item" data-service="dane.gg (Website)">
+                        <div class="status-item" data-service="dane.gg">
                             <span class="service">dane.gg</span>
                             <span class="state ok">[ OK ]</span>
                         </div>
-                        <div class="status-item" data-service="dane.lol (Website)">
+                        <div class="status-item" data-service="dane.lol">
                             <span class="service">dane.lol</span>
                             <span class="state ok">[ OK ]</span>
                         </div>


### PR DESCRIPTION
This pull request includes a small change to the `public/index.html` file. The change involves removing the "(Website)" text from the `data-service` attribute of the `status-item` elements.

* [`public/index.html`](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL343-R347): Removed "(Website)" from the `data-service` attribute of the `status-item` elements for `dane.gg` and `dane.lol`.