### PR TITLE
Update processImageUrl to return undefined for missing thumbnails

### DIFF
--- a/services/rss.js
+++ b/services/rss.js
@@ -54,7 +54,7 @@ export default class RssService {
   }
 
   processImageUrl(thumbnail) {
-    if (!thumbnail) return 'https://dane.gg/assets/img/misc/social-thumbnail.jpg';
+    if (!thumbnail) return undefined;
     return thumbnail.startsWith('http') ? thumbnail : `https://dane.gg${thumbnail}`;
   }
 


### PR DESCRIPTION
This pull request includes a small but important change to the `RssService` class in the `services/rss.js` file. The change modifies the `processImageUrl` method to return `undefined` instead of a default image URL when the `thumbnail` parameter is not provided.

* [`services/rss.js`](diffhunk://#diff-a44c8dd6776d33444381afba0f8ab0dedf2da91b358fb1c2495c4d5d80086d5bL57-R57): Modified the `processImageUrl` method to return `undefined` if the `thumbnail` parameter is not provided, instead of returning a default image URL.