### PR TITLE
Refactor SQL query in RssService

### DIFF
--- a/services/rss.js
+++ b/services/rss.js
@@ -62,14 +62,14 @@ export default class RssService {
     try {
       const query = `
         SELECT 
-          p.title,
-          p.slug,
-          p.content,
-          p.created_at,
-          p.thumbnail
-        FROM website.posts p
-        WHERE p.published = true 
-        ORDER BY p.created_at DESC
+          title,
+          slug,
+          content,
+          created_at,
+          thumbnail
+        FROM website.posts
+        WHERE published = true 
+        ORDER BY created_at DESC
         LIMIT 15`;
       
       const { rows: posts } = await pool.query(query);


### PR DESCRIPTION
This pull request includes a modification to the `RssService` class in the `services/rss.js` file. The change simplifies the SQL query by removing the table alias `p` and directly referencing the column names.

Changes in `services/rss.js`:

* Simplified the SQL query by removing the table alias `p` and directly referencing the columns `title`, `slug`, `content`, `created_at`, and `thumbnail`.