### PR TITLE
Initialize feed items array in generateFeed method

### DIFF
--- a/services/rss.js
+++ b/services/rss.js
@@ -60,6 +60,8 @@ export default class RssService {
 
   async generateFeed() {
     try {
+      this.feed.items = [];
+
       const query = `
         SELECT 
           title,


### PR DESCRIPTION
This pull request includes a small change to the `RssService` class in the `services/rss.js` file. The change ensures that the `feed.items` array is cleared before generating a new feed.

* [`services/rss.js`](diffhunk://#diff-a44c8dd6776d33444381afba0f8ab0dedf2da91b358fb1c2495c4d5d80086d5bR63-R64): Added a line to clear the `feed.items` array at the beginning of the `generateFeed` method.