### PR TITLE
Add published_at timestamp to posts table schema

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -42,6 +42,7 @@ CREATE TABLE website.posts (
     content TEXT NOT NULL,
     thumbnail VARCHAR(255),
     published BOOLEAN DEFAULT false,
+    published_at TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT title_length CHECK (char_length(title) >= 3),


### PR DESCRIPTION
This pull request includes changes to the `schema.sql` file to enhance the database schema for the `website.posts` table. The most important change is the addition of a new column to store the publication timestamp of posts.

Database schema changes:

* [`schema.sql`](diffhunk://#diff-939acd018b931292330e519becd8d003ed0dd20c5e42de62ec3d37553698739aR45): Added a `published_at` column with the type `TIMESTAMP WITH TIME ZONE` to the `website.posts` table to record the publication time of posts.