### PR TITLE
fixed crypto import error in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ import http from 'http';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import { trackPageView } from './middleware/stats.js';
 import cookieParser from 'cookie-parser';
+import crypto from 'crypto';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);


### PR DESCRIPTION
I had some issues with running this page because the crypto package is used in +server.js but not imported.