### PR TITLE
Remove top-level await from web-neko init to fix layout crash

### DIFF
--- a/frontend/src/lib/site/oneko/variants.ts
+++ b/frontend/src/lib/site/oneko/variants.ts
@@ -210,13 +210,20 @@ if (browser) {
 	globalThis.addEventListener(SITE_CONFIG_UPDATED_EVENT, () => reconcileWebNekoFromConfig());
 
 	// Cross-tab: admin saved in another tab of the same browser.
-	subscribeSiteConfigBroadcast(async () => {
-		await loadSiteConfig();
-		reconcileWebNekoFromConfig();
+	subscribeSiteConfigBroadcast(() => {
+		loadSiteConfig()
+			.then(() => reconcileWebNekoFromConfig())
+			.catch(() => {});
 	});
 
 	// Initial load: correct the boot-time skin once fresh config is available,
 	// covering new visitors whose injected default was served stale.
-	await loadSiteConfig();
-	reconcileWebNekoFromConfig();
+	//
+	// NOTE: do NOT convert this to top-level `await`. This module is a
+	// side-effect import in the site layout; a top-level await makes it an async
+	// module and reorders the layout's import graph, causing a "Cannot access
+	// 'SettingsPanel' before initialization" TDZ crash. Keep it fire-and-forget.
+	loadSiteConfig()
+		.then(() => reconcileWebNekoFromConfig())
+		.catch(() => {});
 }

--- a/frontend/src/lib/site/oneko/variants.ts
+++ b/frontend/src/lib/site/oneko/variants.ts
@@ -202,6 +202,21 @@ function reconcileWebNekoFromConfig(): void {
 	if (typeof w.daneRestartWebNeko === 'function') w.daneRestartWebNeko();
 }
 
+/**
+ * Reload the live site config, then re-apply the Web Neko skin.
+ *
+ * The promise handling lives inside this function on purpose. This module is a
+ * side-effect import in the site layout: a *top-level* `await` (or promise
+ * chain) would make it an async module, reorder the layout's import graph, and
+ * cause a "Cannot access 'SettingsPanel' before initialization" TDZ crash. By
+ * keeping the fire-and-forget inside a function, the module stays synchronous.
+ */
+function refreshWebNekoFromConfig(): void {
+	loadSiteConfig()
+		.then(() => reconcileWebNekoFromConfig())
+		.catch(() => {});
+}
+
 if (browser) {
 	// Live server push: when an admin changes config, the backend broadcasts over
 	// the chat WebSocket, which reloads siteConfig and dispatches this event. The
@@ -210,20 +225,9 @@ if (browser) {
 	globalThis.addEventListener(SITE_CONFIG_UPDATED_EVENT, () => reconcileWebNekoFromConfig());
 
 	// Cross-tab: admin saved in another tab of the same browser.
-	subscribeSiteConfigBroadcast(() => {
-		loadSiteConfig()
-			.then(() => reconcileWebNekoFromConfig())
-			.catch(() => {});
-	});
+	subscribeSiteConfigBroadcast(() => refreshWebNekoFromConfig());
 
 	// Initial load: correct the boot-time skin once fresh config is available,
 	// covering new visitors whose injected default was served stale.
-	//
-	// NOTE: do NOT convert this to top-level `await`. This module is a
-	// side-effect import in the site layout; a top-level await makes it an async
-	// module and reorders the layout's import graph, causing a "Cannot access
-	// 'SettingsPanel' before initialization" TDZ crash. Keep it fire-and-forget.
-	loadSiteConfig()
-		.then(() => reconcileWebNekoFromConfig())
-		.catch(() => {});
+	refreshWebNekoFromConfig();
 }


### PR DESCRIPTION
The top-level `await loadSiteConfig()` in variants.ts (a side-effect import in the site layout) made it an async module, reordering the layout's import graph and triggering a "Cannot access 'SettingsPanel' before initialization" crash in the WebKit e2e tests. Revert to fire-and-forget so the module stays synchronous.