### PR TITLE
Store uploaded chat sounds in persistent /uploads/chat-sounds

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,7 +20,6 @@ app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 
 app.use('/uploads', express.static(path.join(process.cwd(), 'static', 'uploads')));
-app.use('/emojis', express.static(path.join(process.cwd(), 'static', 'emojis')));
 app.use('/chat-sounds', express.static(path.join(process.cwd(), 'static', 'chat-sounds')));
 
 // Session configuration

--- a/backend/src/routes/chatNotificationSounds.ts
+++ b/backend/src/routes/chatNotificationSounds.ts
@@ -17,7 +17,9 @@ const router = Router();
 
 const soundStorage = multer.diskStorage({
 	destination: (req, file, cb) => {
-		const uploadDir = path.join(process.cwd(), 'static', 'chat-sounds');
+		// Custom uploads live under the persistent `uploads` volume.
+		// Only the built-in default sound ships in static/chat-sounds via the image.
+		const uploadDir = path.join(process.cwd(), 'static', 'uploads', 'chat-sounds');
 		if (!fs.existsSync(uploadDir)) {
 			fs.mkdirSync(uploadDir, { recursive: true });
 		}
@@ -108,7 +110,7 @@ router.post(
 				return res.status(500).json({ success: false, error: 'Unexpected file name collision' });
 			}
 
-			const soundUrl = `/chat-sounds/${req.file.filename}`;
+			const soundUrl = `/uploads/chat-sounds/${req.file.filename}`;
 			const [row] = await db
 				.insert(chatNotificationSounds)
 				.values({


### PR DESCRIPTION
Uploads went to the non-volume static/chat-sounds and were wiped on every redeploy. Write them to static/uploads/chat-sounds (persistent `uploads` volume) and store /uploads/chat-sounds/<file> URLs. Default sound stays in static/chat-sounds unchanged.