### PR TITLE
Copy-to-clipboard social links for non-URL handles

### DIFF
--- a/backend/drizzle/0010_military_may_parker.sql
+++ b/backend/drizzle/0010_military_may_parker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "website"."social_links" ADD COLUMN "link_type" varchar(10) DEFAULT 'link' NOT NULL;

--- a/backend/drizzle/meta/0010_snapshot.json
+++ b/backend/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,2469 @@
+{
+  "id": "74198654-7ade-4253-88cb-8337d09b9f0e",
+  "prevId": "2747c48f-4f81-45f6-b345-de3d0d67b8d9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "website.adverts": {
+      "name": "adverts",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.api_keys": {
+      "name": "api_keys",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_created_by_users_id_fk": {
+          "name": "api_keys_created_by_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "schemaTo": "website",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_prefix_unique": {
+          "name": "api_keys_key_prefix_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_prefix"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.blog_tags": {
+      "name": "blog_tags",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blog_tags_name_unique": {
+          "name": "blog_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.certifications": {
+      "name": "certifications",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned": {
+          "name": "earned",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_present": {
+          "name": "is_present",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Active'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_external": {
+          "name": "is_external",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.chat_notification_sounds": {
+      "name": "chat_notification_sounds",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sound_url": {
+          "name": "sound_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_notification_sounds_created_by_users_id_fk": {
+          "name": "chat_notification_sounds_created_by_users_id_fk",
+          "tableFrom": "chat_notification_sounds",
+          "tableTo": "users",
+          "schemaTo": "website",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_notification_sounds_name_unique": {
+          "name": "chat_notification_sounds_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.contact_emails": {
+      "name": "contact_emails",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.contact_page_settings": {
+      "name": "contact_page_settings",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contact_page_settings_key_unique": {
+          "name": "contact_page_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.discord_status": {
+      "name": "discord_status",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_update": {
+          "name": "last_update",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.emojis": {
+      "name": "emojis",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "discord_emoji_id": {
+          "name": "discord_emoji_id",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "animated": {
+          "name": "animated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "emojis_created_by_users_id_fk": {
+          "name": "emojis_created_by_users_id_fk",
+          "tableFrom": "emojis",
+          "tableTo": "users",
+          "schemaTo": "website",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "emojis_name_unique": {
+          "name": "emojis_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "emojis_discord_emoji_id_unique": {
+          "name": "emojis_discord_emoji_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_emoji_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.fonts": {
+      "name": "fonts",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "google_font_family": {
+          "name": "google_font_family",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.messages": {
+      "name": "messages",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_color": {
+          "name": "message_color",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_source": {
+          "name": "message_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'web'"
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_uuid": {
+          "name": "client_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.post_tags": {
+      "name": "post_tags",
+      "schema": "website",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "schemaTo": "website",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_blog_tags_id_fk": {
+          "name": "post_tags_tag_id_blog_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "blog_tags",
+          "schemaTo": "website",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "name": "post_tags_post_id_tag_id_pk",
+          "columns": [
+            "post_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.posts": {
+      "name": "posts",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.project_categories": {
+      "name": "project_categories",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_categories_name_unique": {
+          "name": "project_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.project_tags": {
+      "name": "project_tags",
+      "schema": "website",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_tags_project_id_projects_id_fk": {
+          "name": "project_tags_project_id_projects_id_fk",
+          "tableFrom": "project_tags",
+          "tableTo": "projects",
+          "schemaTo": "website",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_tags_tag_id_tags_id_fk": {
+          "name": "project_tags_tag_id_tags_id_fk",
+          "tableFrom": "project_tags",
+          "tableTo": "tags",
+          "schemaTo": "website",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_tags_project_id_tag_id_pk": {
+          "name": "project_tags_project_id_tag_id_pk",
+          "columns": [
+            "project_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.projects": {
+      "name": "projects",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Active'"
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "project_url": {
+          "name": "project_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_text": {
+          "name": "project_text",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'View Project'"
+        },
+        "project_icon": {
+          "name": "project_icon",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_text": {
+          "name": "repo_text",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'View Repository'"
+        },
+        "repo_icon": {
+          "name": "repo_icon",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_bg_color": {
+          "name": "logo_bg_color",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_border": {
+          "name": "logo_border",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_category_id_project_categories_id_fk": {
+          "name": "projects_category_id_project_categories_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "project_categories",
+          "schemaTo": "website",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.site_config": {
+      "name": "site_config",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'string'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "site_config_key_unique": {
+          "name": "site_config_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.skill_categories": {
+      "name": "skill_categories",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skill_categories_name_unique": {
+          "name": "skill_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.skills": {
+      "name": "skills",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skills_category_id_skill_categories_id_fk": {
+          "name": "skills_category_id_skill_categories_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "skill_categories",
+          "schemaTo": "website",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.social_links": {
+      "name": "social_links",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'link'"
+        },
+        "icon_type": {
+          "name": "icon_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'coreui-brand'"
+        },
+        "icon_name": {
+          "name": "icon_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_text": {
+          "name": "icon_text",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "svg_url": {
+          "name": "svg_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "svg_inline": {
+          "name": "svg_inline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.tags": {
+      "name": "tags",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_category_id_project_categories_id_fk": {
+          "name": "tags_category_id_project_categories_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "project_categories",
+          "schemaTo": "website",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.theme_categories": {
+      "name": "theme_categories",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "theme_categories_name_unique": {
+          "name": "theme_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.themes": {
+      "name": "themes",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#ffffff'"
+        },
+        "secondary_color": {
+          "name": "secondary_color",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#a1a1aa'"
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#6366f1'"
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0a0a0a'"
+        },
+        "surface_color": {
+          "name": "surface_color",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#1a1a1a'"
+        },
+        "border_color": {
+          "name": "border_color",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#2a2a2a'"
+        },
+        "text_primary": {
+          "name": "text_primary",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#ffffff'"
+        },
+        "text_secondary": {
+          "name": "text_secondary",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#a1a1aa'"
+        },
+        "text_muted": {
+          "name": "text_muted",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#71717a'"
+        },
+        "background_image": {
+          "name": "background_image",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_image_external": {
+          "name": "background_image_external",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "background_overlay": {
+          "name": "background_overlay",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'rgba(0, 0, 0, 0.7)'"
+        },
+        "background_blur": {
+          "name": "background_blur",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "background_position": {
+          "name": "background_position",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'center center'"
+        },
+        "background_size": {
+          "name": "background_size",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cover'"
+        },
+        "background_attachment": {
+          "name": "background_attachment",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'fixed'"
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Inter'"
+        },
+        "heading_font_family": {
+          "name": "heading_font_family",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Inter'"
+        },
+        "font_scale": {
+          "name": "font_scale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1'"
+        },
+        "border_radius": {
+          "name": "border_radius",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8px'"
+        },
+        "widget_border_radius": {
+          "name": "widget_border_radius",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8px'"
+        },
+        "custom_css": {
+          "name": "custom_css",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanlines_opacity": {
+          "name": "scanlines_opacity",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "overlay_vignette_opacity": {
+          "name": "overlay_vignette_opacity",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "overlay_grid_opacity": {
+          "name": "overlay_grid_opacity",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "overlay_grain_opacity": {
+          "name": "overlay_grain_opacity",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "overlay_glare_opacity": {
+          "name": "overlay_glare_opacity",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "overlay_darken_opacity": {
+          "name": "overlay_darken_opacity",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "themes_category_id_theme_categories_id_fk": {
+          "name": "themes_category_id_theme_categories_id_fk",
+          "tableFrom": "themes",
+          "tableTo": "theme_categories",
+          "schemaTo": "website",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.totp_backup_codes": {
+      "name": "totp_backup_codes",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "totp_backup_codes_user_id_users_id_fk": {
+          "name": "totp_backup_codes_user_id_users_id_fk",
+          "tableFrom": "totp_backup_codes",
+          "tableTo": "users",
+          "schemaTo": "website",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.tweets": {
+      "name": "tweets",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tweet_id": {
+          "name": "tweet_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_username": {
+          "name": "author_username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_profile_image": {
+          "name": "author_profile_image",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_profile_url": {
+          "name": "author_profile_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tweet_url": {
+          "name": "tweet_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tweets_tweet_id_unique": {
+          "name": "tweets_tweet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tweet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.uptime_kuma_monitors": {
+      "name": "uptime_kuma_monitors",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_name": {
+          "name": "custom_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uptime": {
+          "name": "uptime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_response_time": {
+          "name": "avg_response_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uptime_kuma_monitors_monitor_id_unique": {
+          "name": "uptime_kuma_monitors_monitor_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "monitor_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.user_uploads": {
+      "name": "user_uploads",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimetype": {
+          "name": "mimetype",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_external": {
+          "name": "is_external",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_uploads_user_id_users_id_fk": {
+          "name": "user_uploads_user_id_users_id_fk",
+          "tableFrom": "user_uploads",
+          "tableTo": "users",
+          "schemaTo": "website",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.users": {
+      "name": "users",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "totp_secret": {
+          "name": "totp_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_enabled": {
+          "name": "totp_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'system'"
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#000000'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "website.visitor_stats": {
+      "name": "visitor_stats",
+      "schema": "website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_time": {
+          "name": "response_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device": {
+          "name": "device",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_resolution": {
+          "name": "screen_resolution",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_vpn": {
+          "name": "is_vpn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "website": "website"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
 			"when": 1783825051971,
 			"tag": "0009_mute_karen_page",
 			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1784075417162,
+			"tag": "0010_military_may_parker",
+			"breakpoints": true
 		}
 	]
 }

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -209,7 +209,10 @@ export const tweets = websiteSchema.table('tweets', {
 export const socialLinks = websiteSchema.table('social_links', {
 	id: uuid('id').primaryKey().defaultRandom(),
 	name: varchar('name', { length: 100 }).notNull(),
+	// For linkType 'link' this is the URL to open; for 'copy' it is the text
+	// (username, wallet address, ...) copied to the visitor's clipboard.
 	url: varchar('url', { length: 500 }).notNull(),
+	linkType: varchar('link_type', { length: 10 }).notNull().default('link'), // 'link' | 'copy'
 	iconType: varchar('icon_type', { length: 20 }).notNull().default('coreui-brand'), // 'coreui-brand', 'svg-url', 'svg-inline', 'custom-text'
 	iconName: varchar('icon_name', { length: 100 }),
 	iconText: varchar('icon_text', { length: 50 }),

--- a/backend/src/routes/socialLinks.ts
+++ b/backend/src/routes/socialLinks.ts
@@ -4,7 +4,8 @@ import { SocialLinksService } from '../services/socialLinksService';
 import { requireSession } from '../middleware/auth';
 import {
 	validateCreateSocialLinkBody,
-	validateUpdateSocialLinkIconFields
+	validateUpdateSocialLinkIconFields,
+	parseLinkType
 } from '../validation/socialLinkPayload';
 
 const router = Router();
@@ -86,6 +87,7 @@ router.post('/', requireSession, async (req, res) => {
 		const link = await SocialLinksService.create({
 			name: validated.name,
 			url: validated.url,
+			linkType: validated.linkType,
 			iconType: validated.iconType,
 			iconName: validated.iconName,
 			iconText: validated.iconText,
@@ -123,6 +125,14 @@ router.put('/:id', requireSession, async (req, res) => {
 			});
 		}
 
+		const linkType = parseLinkType(req.body.linkType);
+		if (typeof linkType !== 'string') {
+			return res.status(400).json({
+				success: false,
+				error: linkType.error
+			});
+		}
+
 		const iconFields = validateUpdateSocialLinkIconFields(req.body);
 		if ('error' in iconFields) {
 			return res.status(400).json({
@@ -136,6 +146,7 @@ router.put('/:id', requireSession, async (req, res) => {
 		const link = await SocialLinksService.update(id, {
 			name,
 			url,
+			linkType: req.body.linkType === undefined ? undefined : linkType,
 			iconType,
 			iconName: iconType === 'coreui-brand' || iconType === 'lucide' ? iconName : null,
 			iconText: iconType === 'custom-text' ? iconText : null,

--- a/backend/src/validation/socialLinkPayload.test.ts
+++ b/backend/src/validation/socialLinkPayload.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { parseLinkType, validateCreateSocialLinkBody } from './socialLinkPayload';
+
+describe('parseLinkType', () => {
+	test('defaults to link when absent', () => {
+		expect(parseLinkType(undefined)).toBe('link');
+		expect(parseLinkType(null)).toBe('link');
+		expect(parseLinkType('')).toBe('link');
+	});
+
+	test('accepts the two valid types', () => {
+		expect(parseLinkType('link')).toBe('link');
+		expect(parseLinkType('copy')).toBe('copy');
+	});
+
+	test('rejects anything else', () => {
+		expect(parseLinkType('paste')).toEqual({ error: expect.stringContaining('link or copy') });
+		expect(parseLinkType(42)).toEqual({ error: expect.stringContaining('link or copy') });
+		expect(parseLinkType({})).toEqual({ error: expect.stringContaining('link or copy') });
+	});
+});
+
+describe('validateCreateSocialLinkBody with linkType', () => {
+	const base = {
+		name: 'Discord',
+		iconType: 'coreui-brand',
+		iconName: 'discord'
+	};
+
+	test('creates a copy-type link with plain text instead of a URL', () => {
+		const result = validateCreateSocialLinkBody({
+			...base,
+			url: 'danewrx',
+			linkType: 'copy'
+		});
+		expect(result).toMatchObject({ url: 'danewrx', linkType: 'copy' });
+	});
+
+	test('defaults to link type when linkType is omitted', () => {
+		const result = validateCreateSocialLinkBody({ ...base, url: 'https://example.com' });
+		expect(result).toMatchObject({ linkType: 'link' });
+	});
+
+	test('missing text for a copy link uses the copy wording', () => {
+		const result = validateCreateSocialLinkBody({ ...base, url: '', linkType: 'copy' });
+		expect(result).toEqual({ error: 'Name and text to copy are required' });
+	});
+
+	test('missing url for a normal link keeps the original wording', () => {
+		const result = validateCreateSocialLinkBody({ ...base, url: '' });
+		expect(result).toEqual({ error: 'Name and URL are required' });
+	});
+
+	test('invalid linkType is rejected before other checks', () => {
+		const result = validateCreateSocialLinkBody({ ...base, url: 'x', linkType: 'nonsense' });
+		expect(result).toEqual({ error: expect.stringContaining('link or copy') });
+	});
+});

--- a/backend/src/validation/socialLinkPayload.ts
+++ b/backend/src/validation/socialLinkPayload.ts
@@ -9,6 +9,11 @@ export const ICON_TYPES = [
 	'custom-text'
 ] as const;
 
+/** 'link' opens the URL; 'copy' copies the stored text to the clipboard. */
+export const LINK_TYPES = ['link', 'copy'] as const;
+
+const LINK_TYPE_ERROR = 'Valid link type is required (link or copy)';
+
 const ICON_TYPE_ERROR =
 	'Valid icon type is required (coreui-brand, lucide, svg-url, svg-inline, or custom-text)';
 
@@ -32,14 +37,31 @@ function asTrimmedSvgField(value: unknown): string {
 
 type CreateNameUrlOk = { nameTrimmed: string; urlTrimmed: string };
 
-function parseCreateNameAndUrl(body: {
-	name?: unknown;
-	url?: unknown;
-}): { error: string } | CreateNameUrlOk {
+function parseCreateNameAndUrl(
+	body: {
+		name?: unknown;
+		url?: unknown;
+	},
+	linkType: string
+): { error: string } | CreateNameUrlOk {
 	if (!isNonEmptyString(body.name) || !isNonEmptyString(body.url)) {
-		return { error: 'Name and URL are required' };
+		return {
+			error:
+				linkType === 'copy' ? 'Name and text to copy are required' : 'Name and URL are required'
+		};
 	}
 	return { nameTrimmed: body.name.trim(), urlTrimmed: body.url.trim() };
+}
+
+/** Returns the validated link type, defaulting to 'link' when absent. */
+export function parseLinkType(value: unknown): { error: string } | string {
+	if (value === undefined || value === null || value === '') {
+		return 'link';
+	}
+	if (typeof value === 'string' && (LINK_TYPES as readonly string[]).includes(value)) {
+		return value;
+	}
+	return { error: LINK_TYPE_ERROR };
 }
 
 function validateCreateIconTypeSpecific(
@@ -77,12 +99,15 @@ function pickCreateIconName(iconType: string, body: { iconName?: unknown }): str
 }
 
 function pickCreateIconText(iconType: string, body: { iconText?: unknown }): string | null {
-	return iconType === 'custom-text' && isNonEmptyString(body.iconText) ? body.iconText.trim() : null;
+	return iconType === 'custom-text' && isNonEmptyString(body.iconText)
+		? body.iconText.trim()
+		: null;
 }
 
 export type ValidatedCreatePayload = {
 	name: string;
 	url: string;
+	linkType: string;
 	iconType: string;
 	iconName: string | null;
 	iconText: string | null;
@@ -95,6 +120,7 @@ export type ValidatedCreatePayload = {
 export function validateCreateSocialLinkBody(body: {
 	name?: unknown;
 	url?: unknown;
+	linkType?: unknown;
 	iconType?: unknown;
 	iconName?: unknown;
 	iconText?: unknown;
@@ -103,7 +129,12 @@ export function validateCreateSocialLinkBody(body: {
 	displayOrder?: unknown;
 	isActive?: unknown;
 }): { error: string } | ValidatedCreatePayload {
-	const nameUrl = parseCreateNameAndUrl(body);
+	const linkType = parseLinkType(body.linkType);
+	if (typeof linkType !== 'string') {
+		return linkType;
+	}
+
+	const nameUrl = parseCreateNameAndUrl(body, linkType);
 	if ('error' in nameUrl) {
 		return nameUrl;
 	}
@@ -127,6 +158,7 @@ export function validateCreateSocialLinkBody(body: {
 	return {
 		name: nameUrl.nameTrimmed,
 		url: nameUrl.urlTrimmed,
+		linkType,
 		iconType,
 		iconName: pickCreateIconName(iconType, body),
 		iconText: pickCreateIconText(iconType, body),

--- a/frontend/src/lib/site/components/widgets/LinksWidget.svelte
+++ b/frontend/src/lib/site/components/widgets/LinksWidget.svelte
@@ -27,6 +27,12 @@
 	let socialLinks: SocialLink[] = $state([]);
 	let isLoading = $state(true);
 
+	// Balance icons across rows: at most 8 per line, rows as even as possible
+	// (e.g. 17 icons render 6+6+5 instead of 8+8+1).
+	const columns = $derived(
+		socialLinks.length > 0 ? Math.ceil(socialLinks.length / Math.ceil(socialLinks.length / 8)) : 8
+	);
+
 	onMount(async () => {
 		try {
 			const response = await fetch('/api/social-links');
@@ -99,7 +105,7 @@
 	</div>
 {:else if socialLinks.length > 0}
 	<div class="links-container">
-		<div class="links-grid">
+		<div class="links-grid" style="--cols: {columns}">
 			{#each socialLinks as link}
 				<button
 					class="link-item"
@@ -243,14 +249,17 @@
 	}
 
 	.links-grid {
-		display: grid;
-		grid-template-columns: repeat(8, 1fr);
-		gap: 4px;
+		/* Flex-wrap instead of a fixed grid: row size comes from --cols
+		   (balanced in the component, max 8) and the last partial row centres. */
+		--grid-gap: 4px;
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: var(--grid-gap);
 		width: 100%;
 		margin: 0;
 		padding: 12px 8px;
 		box-sizing: border-box;
-		grid-auto-rows: min-content;
 	}
 
 	.link-item {
@@ -258,7 +267,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: 100%;
+		flex: 0 0 calc((100% - (var(--cols, 8) - 1) * var(--grid-gap)) / var(--cols, 8));
 		height: 24px;
 		background: transparent !important;
 		border: none !important;
@@ -399,17 +408,17 @@
 		font-family: var(--font-family, 'Inter', sans-serif);
 	}
 
-	/* Maintain 8 links per row on all screen sizes */
+	/* Same row balance on all screen sizes; only gaps/padding shrink */
 	@media (max-width: 1024px) {
 		.links-grid {
-			gap: 3px;
+			--grid-gap: 3px;
 			--gap-height: 3px;
 		}
 	}
 
 	@media (max-width: 768px) {
 		.links-grid {
-			gap: 2px;
+			--grid-gap: 2px;
 			padding: 10px 6px;
 			--base-padding: 20px;
 			--icon-height: 24px;
@@ -434,7 +443,7 @@
 
 	@media (max-width: 480px) {
 		.links-grid {
-			gap: 2px;
+			--grid-gap: 2px;
 			padding: 8px 4px;
 			--base-padding: 16px;
 			--icon-height: 24px;

--- a/frontend/src/lib/site/components/widgets/LinksWidget.svelte
+++ b/frontend/src/lib/site/components/widgets/LinksWidget.svelte
@@ -1,15 +1,20 @@
 <script lang="ts">
 	import { logger } from '$lib/logger';
 
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import Icon from '@iconify/svelte';
 	import { sanitizeSvgInlineMarkup } from '@repo/shared/utils/sanitizeSvgInline';
-	import { getIconRenderInfo, isLikelyLucideMisstoredAsCoreUi, stripCoreUIBrandPrefix } from '$lib/site/utils/iconHelper';
+	import {
+		getIconRenderInfo,
+		isLikelyLucideMisstoredAsCoreUi,
+		stripCoreUIBrandPrefix
+	} from '$lib/site/utils/iconHelper';
 
 	interface SocialLink {
 		id: string;
 		name: string;
 		url: string;
+		linkType?: 'link' | 'copy';
 		iconType: 'coreui-brand' | 'lucide' | 'svg-url' | 'svg-inline' | 'custom-text';
 		iconName?: string;
 		iconText?: string;
@@ -42,8 +47,47 @@
 		}
 	});
 
-	function handleLinkClick(url: string) {
-		window.open(url, '_blank', 'noopener,noreferrer');
+	// Copy-to-clipboard feedback. The tooltip is portaled to <body> and
+	// positioned with fixed coordinates so it floats above the widget's
+	// bordered container instead of being clipped inside it.
+	let copiedText = $state('');
+	let copyFailed = $state(false);
+	let tooltipVisible = $state(false);
+	let tooltipX = $state(0);
+	let tooltipY = $state(0);
+	let copyResetTimer: ReturnType<typeof setTimeout> | undefined;
+
+	onDestroy(() => clearTimeout(copyResetTimer));
+
+	/** Move an element to <body> so no ancestor overflow/transform clips it. */
+	function portal(node: HTMLElement) {
+		document.body.appendChild(node);
+		return {
+			destroy() {
+				node.remove();
+			}
+		};
+	}
+
+	async function handleLinkClick(link: SocialLink, trigger: HTMLElement) {
+		if (link.linkType === 'copy') {
+			copiedText = link.url;
+			try {
+				await navigator.clipboard.writeText(link.url);
+				copyFailed = false;
+			} catch (error) {
+				logger.error('Clipboard write failed:', error);
+				copyFailed = true;
+			}
+			const rect = trigger.getBoundingClientRect();
+			tooltipX = rect.left + rect.width / 2;
+			tooltipY = rect.top;
+			tooltipVisible = true;
+			clearTimeout(copyResetTimer);
+			copyResetTimer = setTimeout(() => (tooltipVisible = false), 2000);
+			return;
+		}
+		window.open(link.url, '_blank', 'noopener,noreferrer');
 	}
 </script>
 
@@ -59,8 +103,8 @@
 			{#each socialLinks as link}
 				<button
 					class="link-item"
-					onclick={() => handleLinkClick(link.url)}
-					aria-label={link.name}
+					onclick={(e) => handleLinkClick(link, e.currentTarget)}
+					aria-label={link.linkType === 'copy' ? `Copy ${link.name} to clipboard` : link.name}
 					title={link.name}
 				>
 					{#if link.iconType === 'custom-text' && link.iconText}
@@ -106,6 +150,18 @@
 			<p>There are currently no links</p>
 		</div>
 	</div>
+{/if}
+
+{#if tooltipVisible}
+	<span
+		use:portal
+		class="copy-tooltip"
+		role="status"
+		style="left: {tooltipX}px; top: {tooltipY}px;"
+	>
+		<strong class="copy-tooltip-text">{copiedText}</strong>
+		<em class="copy-tooltip-label">{copyFailed ? '(copy failed)' : '(copied)'}</em>
+	</span>
 {/if}
 
 <style>
@@ -198,6 +254,7 @@
 	}
 
 	.link-item {
+		position: relative;
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -252,6 +309,43 @@
 		outline: none !important;
 		box-shadow: none !important;
 		background: transparent !important;
+	}
+
+	.copy-tooltip {
+		/* Portaled to <body>; left/top come from the clicked button's rect and
+		   the transform centres it horizontally and lifts it above the button. */
+		position: fixed;
+		transform: translate(-50%, calc(-100% - 8px));
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2px;
+		background: var(--bg-secondary, #1f2937);
+		color: var(--text-primary, #ffffff);
+		border: 1px solid var(--accent-color, #3b82f6);
+		border-radius: 4px;
+		padding: 6px 10px;
+		/* Fixed size: the trigger button's em-based font is tiny. */
+		font-size: 13px;
+		line-height: 1.3;
+		z-index: 9999;
+		pointer-events: none;
+	}
+
+	.copy-tooltip-text {
+		font-weight: 700;
+		white-space: nowrap;
+		max-width: 260px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.copy-tooltip-label {
+		font-style: italic;
+		font-weight: 400;
+		font-size: 11px;
+		color: var(--text-secondary, #9ca3af);
+		white-space: nowrap;
 	}
 
 	.text-icon {

--- a/frontend/src/lib/site/components/widgets/LinksWidget.svelte
+++ b/frontend/src/lib/site/components/widgets/LinksWidget.svelte
@@ -9,6 +9,7 @@
 		isLikelyLucideMisstoredAsCoreUi,
 		stripCoreUIBrandPrefix
 	} from '$lib/site/utils/iconHelper';
+	import { balancedColumns } from '$lib/site/utils/balancedColumns';
 
 	interface SocialLink {
 		id: string;
@@ -29,9 +30,7 @@
 
 	// Balance icons across rows: at most 8 per line, rows as even as possible
 	// (e.g. 17 icons render 6+6+5 instead of 8+8+1).
-	const columns = $derived(
-		socialLinks.length > 0 ? Math.ceil(socialLinks.length / Math.ceil(socialLinks.length / 8)) : 8
-	);
+	const columns = $derived(balancedColumns(socialLinks.length));
 
 	onMount(async () => {
 		try {

--- a/frontend/src/lib/site/utils/balancedColumns.test.ts
+++ b/frontend/src/lib/site/utils/balancedColumns.test.ts
@@ -69,7 +69,7 @@ describe('balancedColumns', () => {
 			const minimalRows = Math.ceil(count / 8);
 			const evenCols = Math.ceil(count / minimalRows);
 			if (count % evenCols !== 1) {
-				expect(rows.length).toBe(minimalRows);
+				expect(rows).toHaveLength(minimalRows);
 			}
 		}
 	});

--- a/frontend/src/lib/site/utils/balancedColumns.test.ts
+++ b/frontend/src/lib/site/utils/balancedColumns.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { balancedColumns } from './balancedColumns';
+
+/** Row sizes produced by wrapping `count` items at `cols` per row. */
+function rowSizes(count: number, cols: number): number[] {
+	const rows: number[] = [];
+	for (let remaining = count; remaining > 0; remaining -= cols) {
+		rows.push(Math.min(cols, remaining));
+	}
+	return rows;
+}
+
+describe('balancedColumns', () => {
+	it('gives a single row up to the maximum', () => {
+		expect(balancedColumns(1)).toBe(1);
+		expect(balancedColumns(3)).toBe(3);
+		expect(balancedColumns(7)).toBe(7);
+		expect(balancedColumns(8)).toBe(8);
+	});
+
+	it('spreads counts just over the maximum instead of orphaning them', () => {
+		// The original bug: 17 icons rendered 8+8+1 with a lone icon on row 3.
+		expect(rowSizes(17, balancedColumns(17))).toEqual([6, 6, 5]);
+		expect(rowSizes(9, balancedColumns(9))).toEqual([5, 4]);
+		expect(rowSizes(12, balancedColumns(12))).toEqual([6, 6]);
+		expect(rowSizes(20, balancedColumns(20))).toEqual([7, 7, 6]);
+		expect(rowSizes(24, balancedColumns(24))).toEqual([8, 8, 8]);
+	});
+
+	it('is near-even, not perfectly even (single column width serves all rows)', () => {
+		// Documented behaviour: 22 renders 8+8+6, not the ideal 8+7+7.
+		expect(rowSizes(22, balancedColumns(22))).toEqual([8, 8, 6]);
+	});
+
+	it('narrows rows when even wrapping would strand a single icon', () => {
+		// 57 would greedily wrap 8+8+8+8+8+8+8+1; narrowing to 6 avoids the orphan.
+		expect(rowSizes(57, balancedColumns(57))).toEqual([6, 6, 6, 6, 6, 6, 6, 6, 6, 3]);
+	});
+
+	it('falls back to the maximum for empty or invalid counts', () => {
+		expect(balancedColumns(0)).toBe(8);
+		expect(balancedColumns(-3)).toBe(8);
+	});
+
+	it('respects a custom maximum', () => {
+		expect(balancedColumns(5, 4)).toBe(3); // 3+2 instead of 4+1
+		expect(rowSizes(5, balancedColumns(5, 4))).toEqual([3, 2]);
+	});
+
+	it('holds its invariants for every count up to 200', () => {
+		for (let count = 1; count <= 200; count++) {
+			const cols = balancedColumns(count);
+			const rows = rowSizes(count, cols);
+
+			// Never more than 8 per row, never a nonsensical column count.
+			expect(cols).toBeGreaterThanOrEqual(1);
+			expect(cols).toBeLessThanOrEqual(8);
+
+			// All items are placed.
+			expect(rows.reduce((a, b) => a + b, 0)).toBe(count);
+
+			// The core guarantee: once wrapping happens, no orphan rows.
+			if (count > 8) {
+				expect(rows[rows.length - 1]).toBeGreaterThanOrEqual(2);
+			}
+
+			// Row count stays minimal unless the even width would have
+			// stranded a single icon (then extra rows are the trade-off).
+			const minimalRows = Math.ceil(count / 8);
+			const evenCols = Math.ceil(count / minimalRows);
+			if (count % evenCols !== 1) {
+				expect(rows.length).toBe(minimalRows);
+			}
+		}
+	});
+});

--- a/frontend/src/lib/site/utils/balancedColumns.ts
+++ b/frontend/src/lib/site/utils/balancedColumns.ts
@@ -1,0 +1,30 @@
+/**
+ * Row-balancing for icon grids: how many columns per row so that `count`
+ * items wrap (greedily, at most `max` per row) into rows that are as even
+ * as possible without stranding a single item on the last row.
+ *
+ * Examples with max 8: 9 -> 5 (rows 5+4), 17 -> 6 (rows 6+6+5). Rows are
+ * near-even rather than perfectly even — 22 -> 8 renders 8+8+6, not 8+7+7 —
+ * because a single column width has to serve every row. Counts like 57
+ * (which would greedily wrap 8+8+...+1) narrow further, trading extra rows
+ * for no orphan.
+ */
+export function balancedColumns(count: number, max = 8): number {
+	if (count <= 0) {
+		return max;
+	}
+	if (count <= max) {
+		return count;
+	}
+	const rows = Math.ceil(count / max);
+	let cols = Math.ceil(count / rows);
+	// Greedy wrapping leaves `count % cols` items on the last row; if that
+	// strands a single icon, narrow the rows until it doesn't. (Within any
+	// realistic count this terminates well above the cols > 2 floor: a count
+	// would need to be ≡ 1 mod every width from `max` down to 3, i.e.
+	// 1 mod lcm(3..8) = 841+ for the default max.)
+	while (cols > 2 && count % cols === 1) {
+		cols--;
+	}
+	return cols;
+}

--- a/frontend/src/routes/(admin)/admin/configuration/social-links/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/social-links/+page.svelte
@@ -410,6 +410,37 @@
 	<title>{adminPageTitle('Social links')}</title>
 </svelte:head>
 
+{#snippet linkTypeField()}
+	<div class="form-group">
+		<span class="segment-label">Type *</span>
+		<div class="segmented" role="group" aria-label="Link type">
+			<button
+				type="button"
+				class="segment"
+				class:active={formData.linkType === 'link'}
+				aria-pressed={formData.linkType === 'link'}
+				onclick={() => (formData.linkType = 'link')}
+			>
+				Link
+			</button>
+			<button
+				type="button"
+				class="segment"
+				class:active={formData.linkType === 'copy'}
+				aria-pressed={formData.linkType === 'copy'}
+				onclick={() => (formData.linkType = 'copy')}
+			>
+				Text
+			</button>
+		</div>
+		<p class="segment-hint">
+			{formData.linkType === 'copy'
+				? 'Copies text (username, address…) to the clipboard when clicked'
+				: 'Opens a URL in a new tab when clicked'}
+		</p>
+	</div>
+{/snippet}
+
 <ConfirmDialog
 	bind:open={showDeleteLinkDialog}
 	title="Delete link"
@@ -477,13 +508,7 @@
 										/>
 									</div>
 
-									<div class="form-group">
-										<label for="link-type">Type *</label>
-										<select id="link-type" class="edit-input" bind:value={formData.linkType}>
-											<option value="link">Link — opens a URL</option>
-											<option value="copy">Copy — copies text to the clipboard</option>
-										</select>
-									</div>
+									{@render linkTypeField()}
 
 									<div class="form-group">
 										{#if formData.linkType === 'copy'}
@@ -682,13 +707,7 @@
 							/>
 						</div>
 
-						<div class="form-group">
-							<label for="link-type-new">Type *</label>
-							<select id="link-type-new" class="edit-input" bind:value={formData.linkType}>
-								<option value="link">Link — opens a URL</option>
-								<option value="copy">Copy — copies text to the clipboard</option>
-							</select>
-						</div>
+						{@render linkTypeField()}
 
 						<div class="form-group">
 							{#if formData.linkType === 'copy'}
@@ -1050,6 +1069,51 @@
 		font-weight: 500;
 		color: var(--text-primary, #ffffff);
 		margin-bottom: 8px;
+	}
+
+	.segment-label {
+		display: block;
+		font-size: 14px;
+		font-weight: 500;
+		color: var(--text-primary, #ffffff);
+		margin-bottom: 8px;
+	}
+
+	.segmented {
+		display: flex;
+		gap: 4px;
+		padding: 4px;
+		background: var(--bg-secondary, #2d2d2d);
+		border: 1px solid var(--border-color, #3a3a3a);
+		border-radius: 8px;
+	}
+
+	.segment {
+		flex: 1;
+		padding: 8px 12px;
+		border: none;
+		border-radius: 5px;
+		background: transparent;
+		color: var(--text-secondary, #9ca3af);
+		font-size: 14px;
+		font-weight: 500;
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.segment:hover:not(.active) {
+		color: var(--text-primary, #ffffff);
+	}
+
+	.segment.active {
+		background: var(--accent-color, #6366f1);
+		color: #ffffff;
+	}
+
+	.segment-hint {
+		margin: 8px 0 0;
+		font-size: 13px;
+		color: var(--text-secondary, #9ca3af);
 	}
 
 	.icon-selection-section {

--- a/frontend/src/routes/(admin)/admin/configuration/social-links/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/social-links/+page.svelte
@@ -16,6 +16,7 @@
 		id: string;
 		name: string;
 		url: string;
+		linkType: 'link' | 'copy';
 		iconType: 'coreui-brand' | 'lucide' | 'svg-url' | 'svg-inline' | 'custom-text';
 		iconName?: string;
 		iconText?: string;
@@ -40,6 +41,7 @@
 	let formData = $state({
 		name: '',
 		url: '',
+		linkType: 'link' as 'link' | 'copy',
 		iconType: 'coreui-brand' as
 			| 'coreui-brand'
 			| 'lucide'
@@ -96,12 +98,8 @@
 			isSaving = true;
 
 			// Determine icon type and values from selectedIcon
-			let iconType:
-				| 'coreui-brand'
-				| 'lucide'
-				| 'svg-url'
-				| 'svg-inline'
-				| 'custom-text' = 'coreui-brand';
+			let iconType: 'coreui-brand' | 'lucide' | 'svg-url' | 'svg-inline' | 'custom-text' =
+				'coreui-brand';
 			let iconName: string | null = null;
 			let iconText: string | null = null;
 			let svgUrl: string | null = null;
@@ -247,6 +245,7 @@
 		formData = {
 			name: link.name,
 			url: link.url,
+			linkType: link.linkType || 'link',
 			iconType: link.iconType,
 			iconName: link.iconName || '',
 			iconText: link.iconText || '',
@@ -301,6 +300,7 @@
 		formData = {
 			name: '',
 			url: '',
+			linkType: 'link',
 			iconType: 'coreui-brand',
 			iconName: '',
 			iconText: '',
@@ -478,15 +478,35 @@
 									</div>
 
 									<div class="form-group">
-										<label for="url">URL *</label>
-										<input
-											type="url"
-											id="url"
-											class="edit-input"
-											bind:value={formData.url}
-											placeholder="https://example.com"
-											required
-										/>
+										<label for="link-type">Type *</label>
+										<select id="link-type" class="edit-input" bind:value={formData.linkType}>
+											<option value="link">Link — opens a URL</option>
+											<option value="copy">Copy — copies text to the clipboard</option>
+										</select>
+									</div>
+
+									<div class="form-group">
+										{#if formData.linkType === 'copy'}
+											<label for="url">Text to Copy *</label>
+											<input
+												type="text"
+												id="url"
+												class="edit-input"
+												bind:value={formData.url}
+												placeholder="e.g., username, wallet address"
+												required
+											/>
+										{:else}
+											<label for="url">URL *</label>
+											<input
+												type="url"
+												id="url"
+												class="edit-input"
+												bind:value={formData.url}
+												placeholder="https://example.com"
+												required
+											/>
+										{/if}
 									</div>
 
 									<div class="form-group">
@@ -503,7 +523,9 @@
 													{#if selectedIcon.type === 'svg-inline' && selectedIcon.svgInline}
 														{@const safeSvg = sanitizeSvgInlineMarkup(selectedIcon.svgInline)}
 														{#if safeSvg}
-															<span class="svg-inline-thumb" aria-hidden="true">{@html safeSvg}</span>
+															<span class="svg-inline-thumb" aria-hidden="true"
+																>{@html safeSvg}</span
+															>
 														{:else}
 															<Icon icon="lucide:image" width="20" height="20" />
 														{/if}
@@ -578,7 +600,12 @@
 										{#if safeListSvg}
 											<span class="svg-inline-thumb" aria-hidden="true">{@html safeListSvg}</span>
 										{:else}
-											<Icon icon="lucide:external-link" width="20" height="20" class="default-icon" />
+											<Icon
+												icon="lucide:external-link"
+												width="20"
+												height="20"
+												class="default-icon"
+											/>
 										{/if}
 									{:else if link.iconType === 'coreui-brand' && link.iconName}
 										<Icon icon={`cib:${link.iconName.replace('cb-', '')}`} width="20" height="20" />
@@ -598,6 +625,9 @@
 									<h3>{link.name}</h3>
 									<p>{link.url}</p>
 									<div class="link-meta">
+										{#if link.linkType === 'copy'}
+											<span class="icon-type">copies to clipboard</span>
+										{/if}
 										<span class="icon-type">{link.iconType}</span>
 										<span class="display-order">Order: {link.displayOrder}</span>
 									</div>
@@ -653,15 +683,35 @@
 						</div>
 
 						<div class="form-group">
-							<label for="url-new">URL *</label>
-							<input
-								type="url"
-								id="url-new"
-								class="edit-input"
-								bind:value={formData.url}
-								placeholder="https://example.com"
-								required
-							/>
+							<label for="link-type-new">Type *</label>
+							<select id="link-type-new" class="edit-input" bind:value={formData.linkType}>
+								<option value="link">Link — opens a URL</option>
+								<option value="copy">Copy — copies text to the clipboard</option>
+							</select>
+						</div>
+
+						<div class="form-group">
+							{#if formData.linkType === 'copy'}
+								<label for="url-new">Text to Copy *</label>
+								<input
+									type="text"
+									id="url-new"
+									class="edit-input"
+									bind:value={formData.url}
+									placeholder="e.g., username, wallet address"
+									required
+								/>
+							{:else}
+								<label for="url-new">URL *</label>
+								<input
+									type="url"
+									id="url-new"
+									class="edit-input"
+									bind:value={formData.url}
+									placeholder="https://example.com"
+									required
+								/>
+							{/if}
 						</div>
 
 						<div class="form-group">

--- a/frontend/src/routes/(site)/contact/+page.svelte
+++ b/frontend/src/routes/(site)/contact/+page.svelte
@@ -435,7 +435,7 @@
 
 	/* Copy-type links render as buttons but look identical to the anchors. */
 	button.social-link {
-		position: relative;
+		align-self: flex-start;
 		background: none;
 		border: none;
 		padding: 0;
@@ -443,6 +443,11 @@
 		font-family: inherit;
 		cursor: pointer;
 		text-align: left;
+	}
+
+	.social-link:focus:not(:focus-visible),
+	.email-link:focus:not(:focus-visible) {
+		outline: none;
 	}
 
 	.copy-tooltip {

--- a/frontend/src/routes/(site)/contact/+page.svelte
+++ b/frontend/src/routes/(site)/contact/+page.svelte
@@ -2,13 +2,17 @@
 	import { logger } from '$lib/logger';
 	import { publicPageTitle } from '$lib/site/pageTitle';
 
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { Mail } from 'lucide-svelte';
 	import Icon from '@iconify/svelte';
 	import TypingHeader from '$lib/shared/components/TypingHeader.svelte';
 	import { marked } from 'marked';
 	import { sanitizeSvgInlineMarkup } from '@repo/shared/utils/sanitizeSvgInline';
-	import { getIconRenderInfo, isLikelyLucideMisstoredAsCoreUi, stripCoreUIBrandPrefix } from '$lib/site/utils/iconHelper';
+	import {
+		getIconRenderInfo,
+		isLikelyLucideMisstoredAsCoreUi,
+		stripCoreUIBrandPrefix
+	} from '$lib/site/utils/iconHelper';
 
 	let taglineContent = $state('');
 	let loadingTagline = $state(true);
@@ -16,20 +20,59 @@
 	let loadingEmails = $state(true);
 	let emailsHeader = $state('');
 	let loadingEmailsHeader = $state(true);
-	let socialLinks = $state<
-		{
-			id: string;
-			name: string;
-			url: string;
-			iconType: string;
-			iconName?: string;
-			iconText?: string;
-			svgUrl?: string;
-			svgInline?: string | null;
-		}[]
-	>([]);
+	interface ContactSocialLink {
+		id: string;
+		name: string;
+		url: string;
+		linkType?: 'link' | 'copy';
+		iconType: string;
+		iconName?: string;
+		iconText?: string;
+		svgUrl?: string;
+		svgInline?: string | null;
+	}
+
+	let socialLinks = $state<ContactSocialLink[]>([]);
 	let socialHeader = $state('');
 	let loadingSocial = $state(true);
+
+	// Copy-to-clipboard feedback. The tooltip is portaled to <body> and
+	// positioned with fixed coordinates so it floats above everything.
+	let copiedText = $state('');
+	let copyFailed = $state(false);
+	let tooltipVisible = $state(false);
+	let tooltipX = $state(0);
+	let tooltipY = $state(0);
+	let copyResetTimer: ReturnType<typeof setTimeout> | undefined;
+
+	onDestroy(() => clearTimeout(copyResetTimer));
+
+	/** Move an element to <body> so no ancestor overflow/transform clips it. */
+	function portal(node: HTMLElement) {
+		document.body.appendChild(node);
+		return {
+			destroy() {
+				node.remove();
+			}
+		};
+	}
+
+	async function copySocialText(link: ContactSocialLink, trigger: HTMLElement) {
+		copiedText = link.url;
+		try {
+			await navigator.clipboard.writeText(link.url);
+			copyFailed = false;
+		} catch (error) {
+			logger.error('Clipboard write failed:', error);
+			copyFailed = true;
+		}
+		const rect = trigger.getBoundingClientRect();
+		tooltipX = rect.left + rect.width / 2;
+		tooltipY = rect.top;
+		tooltipVisible = true;
+		clearTimeout(copyResetTimer);
+		copyResetTimer = setTimeout(() => (tooltipVisible = false), 2000);
+	}
 
 	onMount(async () => {
 		await Promise.all([loadTagline(), loadContactEmails(), loadEmailsHeader(), loadSocialLinks()]);
@@ -188,6 +231,44 @@
 		{/if}
 	</div>
 
+	{#snippet socialIcon(link: ContactSocialLink)}
+		{#if link.iconType === 'custom-text' && link.iconText}
+			<span class="text-icon">{link.iconText}</span>
+		{:else if link.iconType === 'svg-url' && link.svgUrl}
+			<img src={link.svgUrl} alt={link.name} class="svg-icon" />
+		{:else if link.iconType === 'svg-inline' && link.svgInline}
+			{@const contactSvg = sanitizeSvgInlineMarkup(link.svgInline)}
+			{#if contactSvg}
+				<span class="svg-inline-host" aria-hidden="true">{@html contactSvg}</span>
+			{:else}
+				<Icon icon="simple-icons:link" width="20" height="20" />
+			{/if}
+		{:else if link.iconType === 'lucide' && link.iconName}
+			{@const contactLucide = getIconRenderInfo(link.iconName)}
+			{#if contactLucide.type === 'component' && contactLucide.component}
+				{@const ContactLucideIcon = contactLucide.component}
+				<ContactLucideIcon size={20} strokeWidth={2} />
+			{:else}
+				<Icon icon="simple-icons:link" width="20" height="20" />
+			{/if}
+		{:else if link.iconType === 'coreui-brand' && link.iconName}
+			{@const contactCoreUi = stripCoreUIBrandPrefix(link.iconName)}
+			{#if isLikelyLucideMisstoredAsCoreUi(link.iconName)}
+				{@const misContact = getIconRenderInfo(contactCoreUi)}
+				{#if misContact.type === 'component' && misContact.component}
+					{@const MisLucide = misContact.component}
+					<MisLucide size={20} strokeWidth={2} />
+				{:else}
+					<Icon icon="simple-icons:link" width="20" height="20" />
+				{/if}
+			{:else}
+				<Icon icon={`cib:${contactCoreUi}`} width="20" height="20" />
+			{/if}
+		{:else}
+			<Icon icon="simple-icons:link" width="20" height="20" />
+		{/if}
+	{/snippet}
+
 	{#if !loadingSocial && socialLinks.length > 0}
 		<hr class="section-divider" />
 		<div class="social-section">
@@ -197,44 +278,22 @@
 			{/if}
 			<div class="social-links">
 				{#each socialLinks as link (link.id)}
-					<a href={link.url} target="_blank" rel="noopener noreferrer" class="social-link">
-						{#if link.iconType === 'custom-text' && link.iconText}
-							<span class="text-icon">{link.iconText}</span>
-						{:else if link.iconType === 'svg-url' && link.svgUrl}
-							<img src={link.svgUrl} alt={link.name} class="svg-icon" />
-						{:else if link.iconType === 'svg-inline' && link.svgInline}
-							{@const contactSvg = sanitizeSvgInlineMarkup(link.svgInline)}
-							{#if contactSvg}
-								<span class="svg-inline-host" aria-hidden="true">{@html contactSvg}</span>
-							{:else}
-								<Icon icon="simple-icons:link" width="20" height="20" />
-							{/if}
-						{:else if link.iconType === 'lucide' && link.iconName}
-							{@const contactLucide = getIconRenderInfo(link.iconName)}
-							{#if contactLucide.type === 'component' && contactLucide.component}
-								{@const ContactLucideIcon = contactLucide.component}
-								<ContactLucideIcon size={20} strokeWidth={2} />
-							{:else}
-								<Icon icon="simple-icons:link" width="20" height="20" />
-							{/if}
-						{:else if link.iconType === 'coreui-brand' && link.iconName}
-							{@const contactCoreUi = stripCoreUIBrandPrefix(link.iconName)}
-							{#if isLikelyLucideMisstoredAsCoreUi(link.iconName)}
-								{@const misContact = getIconRenderInfo(contactCoreUi)}
-								{#if misContact.type === 'component' && misContact.component}
-									{@const MisLucide = misContact.component}
-									<MisLucide size={20} strokeWidth={2} />
-								{:else}
-									<Icon icon="simple-icons:link" width="20" height="20" />
-								{/if}
-							{:else}
-								<Icon icon={`cib:${contactCoreUi}`} width="20" height="20" />
-							{/if}
-						{:else}
-							<Icon icon="simple-icons:link" width="20" height="20" />
-						{/if}
-						<span>{link.name}</span>
-					</a>
+					{#if link.linkType === 'copy'}
+						<button
+							type="button"
+							class="social-link copy-link"
+							onclick={(e) => copySocialText(link, e.currentTarget)}
+							aria-label={`Copy ${link.name} to clipboard`}
+						>
+							{@render socialIcon(link)}
+							<span>{link.name}</span>
+						</button>
+					{:else}
+						<a href={link.url} target="_blank" rel="noopener noreferrer" class="social-link">
+							{@render socialIcon(link)}
+							<span>{link.name}</span>
+						</a>
+					{/if}
 				{/each}
 			</div>
 		</div>
@@ -249,6 +308,18 @@
 		</div>
 	</div>
 </div>
+
+{#if tooltipVisible}
+	<span
+		use:portal
+		class="copy-tooltip"
+		role="status"
+		style="left: {tooltipX}px; top: {tooltipY}px;"
+	>
+		<strong class="copy-tooltip-text">{copiedText}</strong>
+		<em class="copy-tooltip-label">{copyFailed ? '(copy failed)' : '(copied)'}</em>
+	</span>
+{/if}
 
 <style>
 	.page-content {
@@ -360,6 +431,54 @@
 
 	.social-link:hover {
 		color: var(--accent-color);
+	}
+
+	/* Copy-type links render as buttons but look identical to the anchors. */
+	button.social-link {
+		position: relative;
+		background: none;
+		border: none;
+		padding: 0;
+		margin: 0;
+		font-family: inherit;
+		cursor: pointer;
+		text-align: left;
+	}
+
+	.copy-tooltip {
+		/* Portaled to <body>; left/top come from the clicked button's rect and
+		   the transform centres it horizontally and lifts it above the button. */
+		position: fixed;
+		transform: translate(-50%, calc(-100% - 8px));
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2px;
+		background: var(--bg-secondary, #1f2937);
+		color: var(--text-primary, #ffffff);
+		border: 1px solid var(--accent-color, #3b82f6);
+		border-radius: 4px;
+		padding: 6px 10px;
+		font-size: 13px;
+		line-height: 1.3;
+		z-index: 9999;
+		pointer-events: none;
+	}
+
+	.copy-tooltip-text {
+		font-weight: 700;
+		white-space: nowrap;
+		max-width: 280px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.copy-tooltip-label {
+		font-style: italic;
+		font-weight: 400;
+		font-size: 11px;
+		color: var(--text-secondary, #9ca3af);
+		white-space: nowrap;
 	}
 
 	.text-icon {


### PR DESCRIPTION
Social links previously required a URL, which made entries like a Discord username or a Bitcoin address impossible. Links can now be either a normal URL or plain text that gets copied to the visitor's clipboard on click, with a floating confirmation tooltip. Also improves the Links widget layout and the admin type selector along the way.