### PR TITLE
GitHub Activity widget + admin config page consistency

### DIFF
--- a/.env.example.dev
+++ b/.env.example.dev
@@ -35,6 +35,11 @@ ADMIN_LOGIN_MAX_FAILED_ATTEMPTS=5 # Failed logins per IP before lockout (and ntf
 LASTFM_API_KEY=lastfm_api_key
 LASTFM_USERNAME=lastfm_username
 
+# GITHUB (contributions widget) — token needs no special scopes for public data
+GITHUB_TOKEN=github_personal_access_token
+GITHUB_ENABLED=true
+GITHUB_USERNAME=danewrx
+
 # TWITTER
 TWITTER_COOKIES=twitter_cookies
 TWITTER_USERNAME=twitter_username

--- a/.env.example.prod
+++ b/.env.example.prod
@@ -42,6 +42,11 @@ ADMIN_LOGIN_MAX_FAILED_ATTEMPTS=5 # Failed logins per IP before lockout (and ntf
 LASTFM_API_KEY=lastfm_api_key
 LASTFM_USERNAME=lastfm_username
 
+# GITHUB (contributions widget) — token needs no special scopes for public data
+GITHUB_TOKEN=github_personal_access_token
+GITHUB_ENABLED=true
+GITHUB_USERNAME=danewrx
+
 # TWITTER
 TWITTER_COOKIES=twitter_cookies
 TWITTER_USERNAME=twitter_username

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -112,6 +112,7 @@ import chatNotificationSoundsRoutes from './routes/chatNotificationSounds';
 import skillsRoutes from './routes/skills';
 import certificationsRoutes from './routes/certifications';
 import advertsRoutes from './routes/adverts';
+import githubRoutes from './routes/github';
 import contactRoutes from './routes/contact';
 import themesRoutes from './routes/themes';
 import fontsRoutes from './routes/fonts';
@@ -212,6 +213,9 @@ app.use('/api/certifications', certificationsRoutes);
 
 // Advertisement routes
 app.use('/api/adverts', advertsRoutes);
+
+// GitHub integration (admin status)
+app.use('/api/github', githubRoutes);
 
 // Contact page routes
 app.use('/api/contact', contactRoutes);

--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -20,7 +20,9 @@ const LIVE_BROADCAST_KEYS = new Set([
 	'advert_enabled',
 	'advert_rotation_seconds',
 	'advert_transition',
-	'advert_transition_duration_ms'
+	'advert_transition_duration_ms',
+	'github_enabled',
+	'github_username'
 ]);
 
 const router = Router();

--- a/backend/src/routes/github.ts
+++ b/backend/src/routes/github.ts
@@ -1,0 +1,41 @@
+import { logger } from '../utils/logger';
+import { Router } from 'express';
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { siteConfig } from '../db/schema';
+import { requireSession } from '../middleware/auth';
+import { GitHubService } from '../services/githubService';
+
+const router = Router();
+
+/**
+ * GET /api/github/status
+ * Admin-only: the resolved username (and whether it comes from the database
+ * override or the GITHUB_USERNAME env var), whether GITHUB_TOKEN is set, and
+ * a live connection test.
+ */
+router.get('/status', requireSession, async (req, res) => {
+	try {
+		const [row] = await db
+			.select()
+			.from(siteConfig)
+			.where(eq(siteConfig.key, 'github_username'))
+			.limit(1);
+
+		const dbUsername = row?.value?.trim() || '';
+		const envUsername = (process.env.GITHUB_USERNAME || '').trim();
+		const username = dbUsername || envUsername;
+		const usernameSource: 'database' | 'environment' = dbUsername ? 'database' : 'environment';
+
+		const tokenConfigured = GitHubService.isConfigured();
+		const connection = await GitHubService.testConnection();
+
+		res.set('Cache-Control', 'no-store');
+		res.json({ tokenConfigured, username, usernameSource, connection });
+	} catch (error) {
+		logger.error('Error fetching GitHub status:', error);
+		res.status(500).json({ error: 'Failed to fetch GitHub status' });
+	}
+});
+
+export default router;

--- a/backend/src/routes/widgets.ts
+++ b/backend/src/routes/widgets.ts
@@ -3,6 +3,8 @@ import { Router } from 'express';
 import { DiscordStatusService } from '../services/discordStatusService';
 import { LastFmService } from '../services/lastfmService';
 import { TweetService } from '../services/tweetService';
+import { GitHubService } from '../services/githubService';
+import { ConfigService } from '../services/config';
 import { getOrSetCached } from '../utils/shortLivedCache';
 
 const router = Router();
@@ -10,6 +12,7 @@ const router = Router();
 const DISCORD_WIDGET_TTL_MS = 20_000;
 const LASTFM_WIDGET_TTL_MS = 15_000;
 const LATEST_TWEET_WIDGET_TTL_MS = 30_000;
+const GITHUB_CONTRIBUTIONS_TTL_MS = 10 * 60_000;
 
 function shouldProxyTwitterImages(): boolean {
 	return (process.env.TWITTER_PROXY_PROFILE_IMAGES ?? 'true').toLowerCase() === 'true';
@@ -112,8 +115,10 @@ router.get('/latest-tweet', async (req, res) => {
 	try {
 		res.set('Cache-Control', 'public, max-age=20, stale-while-revalidate=120');
 
-		const latestTweet = await getOrSetCached('widget:latest-tweet', LATEST_TWEET_WIDGET_TTL_MS, () =>
-			TweetService.getLatestTweet()
+		const latestTweet = await getOrSetCached(
+			'widget:latest-tweet',
+			LATEST_TWEET_WIDGET_TTL_MS,
+			() => TweetService.getLatestTweet()
 		);
 
 		if (!latestTweet) {
@@ -186,6 +191,39 @@ router.get('/tweet-profile-image', async (req, res) => {
 	} catch (error: any) {
 		logger.error('Error proxying tweet profile image:', error);
 		res.status(500).json({ error: 'Failed to fetch image' });
+	}
+});
+
+/**
+ * GET /api/widgets/github-contributions
+ * Trailing-year GitHub contribution calendar for the configured user.
+ */
+router.get('/github-contributions', async (req, res) => {
+	try {
+		// Not publicly cached: the response depends on config that can change, and
+		// the backend already caches the GitHub data in memory for 10 minutes.
+		res.set('Cache-Control', 'no-store');
+
+		const data = await getOrSetCached(
+			'widget:github-contributions',
+			GITHUB_CONTRIBUTIONS_TTL_MS,
+			async () => {
+				const username = ((await ConfigService.get('github_username')) as string) || '';
+				if (!username || !GitHubService.isConfigured()) {
+					return null;
+				}
+				return GitHubService.getContributions(username);
+			}
+		);
+
+		if (!data) {
+			return res.json({ configured: false, totalContributions: 0, weeks: [] });
+		}
+
+		res.json({ configured: true, ...data });
+	} catch (error) {
+		logger.error('Error fetching GitHub contributions:', error);
+		res.status(500).json({ error: 'Failed to fetch GitHub contributions' });
 	}
 });
 

--- a/backend/src/services/config.ts
+++ b/backend/src/services/config.ts
@@ -26,6 +26,10 @@ export interface SiteConfig {
 	advert_transition: string;
 	/** Duration (milliseconds). */
 	advert_transition_duration_ms: number;
+	/** Whether the homepage GitHub contributions widget is shown. */
+	github_enabled: boolean;
+	/** GitHub username whose contribution calendar is displayed. */
+	github_username: string;
 }
 
 // Environment variable fallbacks
@@ -46,7 +50,9 @@ const ENV_FALLBACKS: Partial<SiteConfig> = {
 	advert_transition: process.env.ADVERT_TRANSITION || 'fade',
 	advert_transition_duration_ms: Number.parseFloat(
 		process.env.ADVERT_TRANSITION_DURATION_MS || '600'
-	)
+	),
+	github_enabled: process.env.GITHUB_ENABLED === 'true',
+	github_username: process.env.GITHUB_USERNAME || ''
 };
 
 function toEnvKey(key: string): string {

--- a/backend/src/services/githubService.test.ts
+++ b/backend/src/services/githubService.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+import { mapContributionCalendar, type ContributionCalendar } from './githubService';
+
+const calendar = (
+	weeks: { date: string; contributionCount: number; contributionLevel: string }[][],
+	total: number
+): ContributionCalendar => ({
+	totalContributions: total,
+	weeks: weeks.map((days) => ({ contributionDays: days }))
+});
+
+describe('mapContributionCalendar', () => {
+	test('maps quartile enums to 0–4 levels', () => {
+		const result = mapContributionCalendar(
+			calendar(
+				[
+					[
+						{ date: '2024-01-07', contributionCount: 0, contributionLevel: 'NONE' },
+						{ date: '2024-01-08', contributionCount: 2, contributionLevel: 'FIRST_QUARTILE' },
+						{ date: '2024-01-09', contributionCount: 5, contributionLevel: 'SECOND_QUARTILE' },
+						{ date: '2024-01-10', contributionCount: 9, contributionLevel: 'THIRD_QUARTILE' },
+						{ date: '2024-01-11', contributionCount: 20, contributionLevel: 'FOURTH_QUARTILE' }
+					]
+				],
+				36
+			),
+			'danewrx'
+		);
+
+		expect(result.weeks[0].days.map((d) => d.level)).toEqual([0, 1, 2, 3, 4]);
+		expect(result.weeks[0].days.map((d) => d.count)).toEqual([0, 2, 5, 9, 20]);
+		expect(result.username).toBe('danewrx');
+		expect(result.totalContributions).toBe(36);
+	});
+
+	test('falls back to level 0 for an unknown contribution level', () => {
+		const result = mapContributionCalendar(
+			calendar([[{ date: '2024-01-07', contributionCount: 3, contributionLevel: 'SURPRISE' }]], 3),
+			'danewrx'
+		);
+		expect(result.weeks[0].days[0].level).toBe(0);
+	});
+
+	test('derives from/to from the first and last day across weeks', () => {
+		const result = mapContributionCalendar(
+			calendar(
+				[
+					[{ date: '2024-01-07', contributionCount: 0, contributionLevel: 'NONE' }],
+					[
+						{ date: '2024-01-14', contributionCount: 1, contributionLevel: 'FIRST_QUARTILE' },
+						{ date: '2024-01-15', contributionCount: 0, contributionLevel: 'NONE' }
+					]
+				],
+				1
+			),
+			'danewrx'
+		);
+		expect(result.from).toBe('2024-01-07');
+		expect(result.to).toBe('2024-01-15');
+	});
+
+	test('returns empty from/to for an empty calendar', () => {
+		const result = mapContributionCalendar(calendar([], 0), 'danewrx');
+		expect(result.from).toBe('');
+		expect(result.to).toBe('');
+		expect(result.weeks).toEqual([]);
+		expect(result.totalContributions).toBe(0);
+	});
+});

--- a/backend/src/services/githubService.ts
+++ b/backend/src/services/githubService.ts
@@ -1,0 +1,200 @@
+import { logger } from '../utils/logger';
+
+export interface GitHubContributionDay {
+	date: string;
+	count: number;
+	/** 0 (none) … 4 (highest), mirrors GitHub's contribution levels. */
+	level: 0 | 1 | 2 | 3 | 4;
+}
+
+export interface GitHubContributionWeek {
+	days: GitHubContributionDay[];
+}
+
+export interface GitHubContributions {
+	username: string;
+	totalContributions: number;
+	weeks: GitHubContributionWeek[];
+	from: string;
+	to: string;
+}
+
+const LEVEL_BY_ENUM: Record<string, 0 | 1 | 2 | 3 | 4> = {
+	NONE: 0,
+	FIRST_QUARTILE: 1,
+	SECOND_QUARTILE: 2,
+	THIRD_QUARTILE: 3,
+	FOURTH_QUARTILE: 4
+};
+
+const CONTRIBUTIONS_QUERY = `
+	query ($login: String!) {
+		user(login: $login) {
+			contributionsCollection {
+				contributionCalendar {
+					totalContributions
+					weeks {
+						contributionDays {
+							date
+							contributionCount
+							contributionLevel
+						}
+					}
+				}
+			}
+		}
+	}
+`;
+
+interface GraphQLDay {
+	date: string;
+	contributionCount: number;
+	contributionLevel: string;
+}
+
+interface GraphQLResponse {
+	data?: {
+		user?: {
+			contributionsCollection?: {
+				contributionCalendar?: {
+					totalContributions: number;
+					weeks: { contributionDays: GraphQLDay[] }[];
+				};
+			};
+		};
+	};
+	errors?: { message: string }[];
+}
+
+export class GitHubService {
+	private static readonly API_URL = 'https://api.github.com/graphql';
+
+	static isConfigured(): boolean {
+		return Boolean(process.env.GITHUB_TOKEN);
+	}
+
+	/**
+	 * Verify the configured token can authenticate against the GitHub API with a
+	 * minimal `viewer { login }` query. Used by the admin status card.
+	 */
+	static async testConnection(): Promise<{
+		connected: boolean;
+		login?: string;
+		message: string;
+	}> {
+		const token = process.env.GITHUB_TOKEN;
+		if (!token) {
+			return { connected: false, message: 'GITHUB_TOKEN is not set' };
+		}
+		try {
+			const response = await fetch(this.API_URL, {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${token}`,
+					'Content-Type': 'application/json',
+					'User-Agent': 'dane.gg-site'
+				},
+				body: JSON.stringify({ query: 'query { viewer { login } }' }),
+				signal: AbortSignal.timeout(10_000)
+			});
+
+			if (response.status === 401) {
+				return { connected: false, message: 'Token rejected (401 Unauthorized)' };
+			}
+			if (!response.ok) {
+				return { connected: false, message: `GitHub API error (HTTP ${response.status})` };
+			}
+
+			const body = (await response.json()) as {
+				data?: { viewer?: { login?: string } };
+				errors?: { message: string }[];
+			};
+			if (body.errors?.length) {
+				return { connected: false, message: body.errors[0].message };
+			}
+			const login = body.data?.viewer?.login;
+			if (!login) {
+				return { connected: false, message: 'No authenticated user returned' };
+			}
+			return { connected: true, login, message: `Authenticated as ${login}` };
+		} catch (error) {
+			logger.error('GitHub connection test failed:', error);
+			return {
+				connected: false,
+				message: error instanceof Error ? error.message : 'Request failed'
+			};
+		}
+	}
+
+	/**
+	 * Fetch the trailing-year contribution calendar for a user via the GitHub
+	 * GraphQL API. Requires a `GITHUB_TOKEN`. Returns null when unconfigured or on error.
+	 */
+	static async getContributions(username: string): Promise<GitHubContributions | null> {
+		const token = process.env.GITHUB_TOKEN;
+		if (!token) {
+			logger.warn('GitHub contributions requested but GITHUB_TOKEN is not set');
+			return null;
+		}
+		const login = username.trim();
+		if (!login) {
+			return null;
+		}
+
+		try {
+			const response = await fetch(this.API_URL, {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${token}`,
+					'Content-Type': 'application/json',
+					'User-Agent': 'dane.gg-site'
+				},
+				body: JSON.stringify({
+					query: CONTRIBUTIONS_QUERY,
+					variables: { login }
+				}),
+				signal: AbortSignal.timeout(10_000)
+			});
+
+			if (!response.ok) {
+				logger.error(`GitHub GraphQL request failed: HTTP ${response.status}`);
+				return null;
+			}
+
+			const body = (await response.json()) as GraphQLResponse;
+			if (body.errors?.length) {
+				logger.error('GitHub GraphQL errors:', body.errors.map((e) => e.message).join('; '));
+				return null;
+			}
+
+			const calendar = body.data?.user?.contributionsCollection?.contributionCalendar;
+			if (!calendar) {
+				logger.warn(`No contribution calendar returned for GitHub user '${login}'`);
+				return null;
+			}
+
+			const weeks: GitHubContributionWeek[] = calendar.weeks.map((week) => ({
+				days: week.contributionDays.map((day) => ({
+					date: day.date,
+					count: day.contributionCount,
+					level: LEVEL_BY_ENUM[day.contributionLevel] ?? 0
+				}))
+			}));
+
+			const allDays = weeks.flatMap((w) => w.days);
+			const from = allDays[0]?.date ?? '';
+			const to = allDays[allDays.length - 1]?.date ?? '';
+
+			return {
+				username: login,
+				totalContributions: calendar.totalContributions,
+				weeks,
+				from,
+				to
+			};
+		} catch (error) {
+			logger.error('Error fetching GitHub contributions:', error);
+			return null;
+		}
+	}
+}

--- a/backend/src/services/githubService.ts
+++ b/backend/src/services/githubService.ts
@@ -52,18 +52,45 @@ interface GraphQLDay {
 	contributionLevel: string;
 }
 
+export interface ContributionCalendar {
+	totalContributions: number;
+	weeks: { contributionDays: GraphQLDay[] }[];
+}
+
 interface GraphQLResponse {
 	data?: {
 		user?: {
 			contributionsCollection?: {
-				contributionCalendar?: {
-					totalContributions: number;
-					weeks: { contributionDays: GraphQLDay[] }[];
-				};
+				contributionCalendar?: ContributionCalendar;
 			};
 		};
 	};
 	errors?: { message: string }[];
+}
+
+/**
+ * Map a GitHub contribution calendar to the widget shape
+ */
+export function mapContributionCalendar(
+	calendar: ContributionCalendar,
+	login: string
+): GitHubContributions {
+	const weeks: GitHubContributionWeek[] = calendar.weeks.map((week) => ({
+		days: week.contributionDays.map((day) => ({
+			date: day.date,
+			count: day.contributionCount,
+			level: LEVEL_BY_ENUM[day.contributionLevel] ?? 0
+		}))
+	}));
+
+	const allDays = weeks.flatMap((w) => w.days);
+	return {
+		username: login,
+		totalContributions: calendar.totalContributions,
+		weeks,
+		from: allDays[0]?.date ?? '',
+		to: allDays[allDays.length - 1]?.date ?? ''
+	};
 }
 
 export class GitHubService {
@@ -173,25 +200,7 @@ export class GitHubService {
 				return null;
 			}
 
-			const weeks: GitHubContributionWeek[] = calendar.weeks.map((week) => ({
-				days: week.contributionDays.map((day) => ({
-					date: day.date,
-					count: day.contributionCount,
-					level: LEVEL_BY_ENUM[day.contributionLevel] ?? 0
-				}))
-			}));
-
-			const allDays = weeks.flatMap((w) => w.days);
-			const from = allDays[0]?.date ?? '';
-			const to = allDays[allDays.length - 1]?.date ?? '';
-
-			return {
-				username: login,
-				totalContributions: calendar.totalContributions,
-				weeks,
-				from,
-				to
-			};
+			return mapContributionCalendar(calendar, login);
 		} catch (error) {
 			logger.error('Error fetching GitHub contributions:', error);
 			return null;

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -24,4 +24,9 @@ test.describe('Homepage', () => {
 		await gotoReady(page, '/');
 		await expect(page.locator('.advert-slot')).toHaveCount(0);
 	});
+
+	test('does not render the GitHub activity widget when disabled', async ({ page }) => {
+		await gotoReady(page, '/');
+		await expect(page.locator('.github-contributions-section')).toHaveCount(0);
+	});
 });

--- a/frontend/src/lib/admin/components/ui/ConfigurationSidebar.svelte
+++ b/frontend/src/lib/admin/components/ui/ConfigurationSidebar.svelte
@@ -16,7 +16,8 @@
 		Award,
 		Mail,
 		Bell,
-		Megaphone
+		Megaphone,
+		Github
 	} from 'lucide-svelte';
 	import type { ComponentType } from 'svelte';
 
@@ -139,6 +140,8 @@
 								<User size={20} stroke-width={1.5} />
 							{:else if category.icon === Megaphone}
 								<Megaphone size={20} stroke-width={1.5} />
+							{:else if category.icon === Github}
+								<Github size={20} stroke-width={1.5} />
 							{/if}
 						</div>
 						<span class="sidebar-title">{category.title}</span>

--- a/frontend/src/lib/site/components/widgets/GitHubContributionsWidget.svelte
+++ b/frontend/src/lib/site/components/widgets/GitHubContributionsWidget.svelte
@@ -1,0 +1,252 @@
+<script lang="ts">
+	import { logger } from '$lib/logger';
+	import { onMount } from 'svelte';
+
+	interface ContributionDay {
+		date: string;
+		count: number;
+		level: 0 | 1 | 2 | 3 | 4;
+	}
+	interface ContributionWeek {
+		days: ContributionDay[];
+	}
+	interface ContributionsResponse {
+		configured: boolean;
+		username?: string;
+		totalContributions: number;
+		weeks: ContributionWeek[];
+	}
+
+	let data = $state<ContributionsResponse | null>(null);
+	let isLoading = $state(true);
+	let hasError = $state(false);
+
+	const weeks = $derived(data?.weeks ?? []);
+	const total = $derived(data?.totalContributions ?? 0);
+	const profileUrl = $derived(data?.username ? `https://github.com/${data.username}` : null);
+
+	// Month labels: one per month, at the week column where it first appears,
+	// skipping labels that would collide with the previous one.
+	const monthLabels = $derived.by(() => {
+		const labels: { col: number; label: string }[] = [];
+		let lastMonth = -1;
+		let lastCol = -3;
+		weeks.forEach((week, i) => {
+			const first = week.days[0];
+			if (!first) return;
+			const d = new Date(`${first.date}T00:00:00`);
+			const month = d.getMonth();
+			if (month !== lastMonth && i - lastCol >= 3) {
+				labels.push({ col: i + 1, label: d.toLocaleString('en-US', { month: 'short' }) });
+				lastMonth = month;
+				lastCol = i;
+			} else if (month !== lastMonth) {
+				lastMonth = month;
+			}
+		});
+		return labels;
+	});
+
+	function weekdayRow(date: string): number {
+		// getDay: 0 = Sunday … 6 = Saturday → grid rows 1…7
+		return new Date(`${date}T00:00:00`).getDay() + 1;
+	}
+
+	function tooltip(day: ContributionDay): string {
+		const label = day.count === 1 ? '1 contribution' : `${day.count} contributions`;
+		const d = new Date(`${day.date}T00:00:00`).toLocaleDateString('en-US', {
+			month: 'short',
+			day: 'numeric',
+			year: 'numeric'
+		});
+		return `${label} on ${d}`;
+	}
+
+	onMount(async () => {
+		try {
+			// Bypass the browser cache so a response fetched before the widget was
+			// configured (or during setup) isn't served stale
+			const response = await fetch('/api/widgets/github-contributions', { cache: 'no-store' });
+			if (!response.ok) throw new Error(`HTTP ${response.status}`);
+			const body = (await response.json()) as ContributionsResponse;
+			data = body;
+		} catch (error) {
+			logger.error('Error loading GitHub contributions:', error);
+			hasError = true;
+		} finally {
+			isLoading = false;
+		}
+	});
+</script>
+
+<div class="github-widget">
+	{#if isLoading}
+		<div class="gh-state">
+			<div class="gh-spinner"></div>
+		</div>
+	{:else if hasError || !data?.configured || weeks.length === 0}
+		<div class="gh-state">
+			<p>GitHub activity is currently unavailable.</p>
+		</div>
+	{:else}
+		<div class="gh-scroll">
+			<div class="gh-chart" style="--weeks: {weeks.length}">
+				<div class="gh-months">
+					{#each monthLabels as m (m.col)}
+						<span class="gh-month" style="grid-column: {m.col}">{m.label}</span>
+					{/each}
+				</div>
+				<div class="gh-grid">
+					{#each weeks as week, w (w)}
+						{#each week.days as day (day.date)}
+							<span
+								class="gh-cell"
+								data-level={day.level}
+								style="grid-column: {w + 1}; grid-row: {weekdayRow(day.date)}"
+								title={tooltip(day)}
+							></span>
+						{/each}
+					{/each}
+				</div>
+			</div>
+		</div>
+
+		<div class="gh-footer">
+			{#if profileUrl}
+				<a href={profileUrl} target="_blank" rel="noopener noreferrer" class="gh-total">
+					{total} contributions in the last year
+				</a>
+			{:else}
+				<span class="gh-total">{total} contributions in the last year</span>
+			{/if}
+			<div class="gh-legend">
+				<span>Less</span>
+				<span class="gh-cell" data-level="0"></span>
+				<span class="gh-cell" data-level="1"></span>
+				<span class="gh-cell" data-level="2"></span>
+				<span class="gh-cell" data-level="3"></span>
+				<span class="gh-cell" data-level="4"></span>
+				<span>More</span>
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.github-widget {
+		width: 100%;
+		padding: 4px 0 8px;
+		box-sizing: border-box;
+	}
+
+	.gh-state {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 120px;
+		color: var(--text-secondary, #9ca3af);
+		font-size: calc(13 * 1em / 14);
+	}
+
+	.gh-spinner {
+		width: 22px;
+		height: 22px;
+		border: 2px solid var(--theme-border, #374151);
+		border-top-color: var(--theme-accent, #6366f1);
+		border-radius: 50%;
+		animation: gh-spin 0.9s linear infinite;
+	}
+
+	@keyframes gh-spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	/* Horizontal scroll only kicks in when the column is too narrow. */
+	.gh-scroll {
+		width: 100%;
+		overflow-x: auto;
+		padding-bottom: 4px;
+	}
+
+	.gh-chart {
+		min-width: 100%;
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.gh-months {
+		display: grid;
+		grid-template-columns: repeat(var(--weeks), 1fr);
+		font-size: calc(10 * 1em / 14);
+		color: var(--text-secondary, #9ca3af);
+		height: 14px;
+	}
+
+	.gh-month {
+		grid-row: 1;
+		white-space: nowrap;
+	}
+
+	.gh-grid {
+		display: grid;
+		grid-template-columns: repeat(var(--weeks), 1fr);
+		grid-template-rows: repeat(7, auto);
+		gap: 2px;
+	}
+
+	.gh-cell {
+		aspect-ratio: 1;
+		width: 100%;
+		border-radius: 2px;
+		background: var(--gh-level-0, rgba(255, 255, 255, 0.06));
+	}
+
+	.gh-cell[data-level='1'] {
+		background: var(--gh-level-1, rgba(255, 255, 255, 0.22));
+	}
+	.gh-cell[data-level='2'] {
+		background: var(--gh-level-2, rgba(255, 255, 255, 0.4));
+	}
+	.gh-cell[data-level='3'] {
+		background: var(--gh-level-3, rgba(255, 255, 255, 0.62));
+	}
+	.gh-cell[data-level='4'] {
+		background: var(--gh-level-4, rgba(255, 255, 255, 0.92));
+	}
+
+	.gh-footer {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		margin-top: 10px;
+		flex-wrap: wrap;
+		font-size: calc(11 * 1em / 14);
+		color: var(--text-secondary, #9ca3af);
+	}
+
+	.gh-total {
+		color: var(--text-secondary, #9ca3af);
+		text-decoration: none;
+	}
+
+	a.gh-total:hover {
+		color: var(--accent-color, #3b82f6);
+	}
+
+	.gh-legend {
+		display: flex;
+		align-items: center;
+		gap: 3px;
+	}
+
+	.gh-legend .gh-cell {
+		width: 11px;
+		height: 11px;
+		aspect-ratio: auto;
+		flex-shrink: 0;
+	}
+</style>

--- a/frontend/src/lib/site/components/widgets/GitHubContributionsWidget.svelte
+++ b/frontend/src/lib/site/components/widgets/GitHubContributionsWidget.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
 	import { logger } from '$lib/logger';
 	import { onMount } from 'svelte';
+	import {
+		computeMonthLabels,
+		weekdayRow,
+		dayTooltip,
+		type ContributionWeek
+	} from '$lib/site/utils/githubContributions';
 
-	interface ContributionDay {
-		date: string;
-		count: number;
-		level: 0 | 1 | 2 | 3 | 4;
-	}
-	interface ContributionWeek {
-		days: ContributionDay[];
-	}
 	interface ContributionsResponse {
 		configured: boolean;
 		username?: string;
@@ -24,43 +22,7 @@
 	const weeks = $derived(data?.weeks ?? []);
 	const total = $derived(data?.totalContributions ?? 0);
 	const profileUrl = $derived(data?.username ? `https://github.com/${data.username}` : null);
-
-	// Month labels: one per month, at the week column where it first appears,
-	// skipping labels that would collide with the previous one.
-	const monthLabels = $derived.by(() => {
-		const labels: { col: number; label: string }[] = [];
-		let lastMonth = -1;
-		let lastCol = -3;
-		weeks.forEach((week, i) => {
-			const first = week.days[0];
-			if (!first) return;
-			const d = new Date(`${first.date}T00:00:00`);
-			const month = d.getMonth();
-			if (month !== lastMonth && i - lastCol >= 3) {
-				labels.push({ col: i + 1, label: d.toLocaleString('en-US', { month: 'short' }) });
-				lastMonth = month;
-				lastCol = i;
-			} else if (month !== lastMonth) {
-				lastMonth = month;
-			}
-		});
-		return labels;
-	});
-
-	function weekdayRow(date: string): number {
-		// getDay: 0 = Sunday … 6 = Saturday → grid rows 1…7
-		return new Date(`${date}T00:00:00`).getDay() + 1;
-	}
-
-	function tooltip(day: ContributionDay): string {
-		const label = day.count === 1 ? '1 contribution' : `${day.count} contributions`;
-		const d = new Date(`${day.date}T00:00:00`).toLocaleDateString('en-US', {
-			month: 'short',
-			day: 'numeric',
-			year: 'numeric'
-		});
-		return `${label} on ${d}`;
-	}
+	const monthLabels = $derived(computeMonthLabels(weeks));
 
 	onMount(async () => {
 		try {
@@ -103,7 +65,7 @@
 								class="gh-cell"
 								data-level={day.level}
 								style="grid-column: {w + 1}; grid-row: {weekdayRow(day.date)}"
-								title={tooltip(day)}
+								title={dayTooltip(day)}
 							></span>
 						{/each}
 					{/each}

--- a/frontend/src/lib/site/components/widgets/GitHubContributionsWidget.svelte
+++ b/frontend/src/lib/site/components/widgets/GitHubContributionsWidget.svelte
@@ -137,6 +137,28 @@
 		width: 100%;
 		padding: 4px 0 8px;
 		box-sizing: border-box;
+
+		/* Base ramp (grayscale) — works everywhere and is the fallback when
+		   color-mix() is unavailable. */
+		--gh-level-0: rgba(255, 255, 255, 0.06);
+		--gh-level-1: rgba(255, 255, 255, 0.22);
+		--gh-level-2: rgba(255, 255, 255, 0.4);
+		--gh-level-3: rgba(255, 255, 255, 0.62);
+		--gh-level-4: rgba(255, 255, 255, 0.92);
+	}
+
+	/* Tint the heatmap with the active theme's accent colour so it matches
+	   whatever theme is applied. */
+	@supports (background: color-mix(in srgb, red, blue)) {
+		.github-widget {
+			--gh-surface: var(--theme-surface, var(--bg-secondary, #1a1a1a));
+			--gh-accent: var(--theme-accent, var(--accent-color, #6366f1));
+			--gh-level-0: color-mix(in srgb, var(--theme-text-primary, #ffffff) 8%, transparent);
+			--gh-level-1: color-mix(in srgb, var(--gh-accent) 28%, var(--gh-surface));
+			--gh-level-2: color-mix(in srgb, var(--gh-accent) 52%, var(--gh-surface));
+			--gh-level-3: color-mix(in srgb, var(--gh-accent) 76%, var(--gh-surface));
+			--gh-level-4: var(--gh-accent);
+		}
 	}
 
 	.gh-state {
@@ -201,20 +223,20 @@
 		aspect-ratio: 1;
 		width: 100%;
 		border-radius: 2px;
-		background: var(--gh-level-0, rgba(255, 255, 255, 0.06));
+		background: var(--gh-level-0);
 	}
 
 	.gh-cell[data-level='1'] {
-		background: var(--gh-level-1, rgba(255, 255, 255, 0.22));
+		background: var(--gh-level-1);
 	}
 	.gh-cell[data-level='2'] {
-		background: var(--gh-level-2, rgba(255, 255, 255, 0.4));
+		background: var(--gh-level-2);
 	}
 	.gh-cell[data-level='3'] {
-		background: var(--gh-level-3, rgba(255, 255, 255, 0.62));
+		background: var(--gh-level-3);
 	}
 	.gh-cell[data-level='4'] {
-		background: var(--gh-level-4, rgba(255, 255, 255, 0.92));
+		background: var(--gh-level-4);
 	}
 
 	.gh-footer {

--- a/frontend/src/lib/site/stores/siteConfig.ts
+++ b/frontend/src/lib/site/stores/siteConfig.ts
@@ -23,6 +23,10 @@ export interface SiteConfig {
 	advert_transition: string;
 	/** How long the transition animation runs (milliseconds). */
 	advert_transition_duration_ms: number;
+	/** Whether the homepage GitHub contributions widget is shown. */
+	github_enabled: boolean;
+	/** GitHub username whose contribution calendar is displayed. */
+	github_username: string;
 }
 
 // Default configuration (fallback)
@@ -39,7 +43,9 @@ const DEFAULT_CONFIG: SiteConfig = {
 	advert_enabled: false,
 	advert_rotation_seconds: 8,
 	advert_transition: 'fade',
-	advert_transition_duration_ms: 600
+	advert_transition_duration_ms: 600,
+	github_enabled: false,
+	github_username: ''
 };
 
 // Store for site configuration

--- a/frontend/src/lib/site/utils/githubContributions.test.ts
+++ b/frontend/src/lib/site/utils/githubContributions.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+	computeMonthLabels,
+	weekdayRow,
+	dayTooltip,
+	type ContributionWeek
+} from './githubContributions';
+
+/** Build weeks starting at `start`, one column per week (all days = level 0). */
+function weeksFrom(start: string, count: number): ContributionWeek[] {
+	const weeks: ContributionWeek[] = [];
+	const cursor = new Date(`${start}T00:00:00`);
+	for (let w = 0; w < count; w++) {
+		const days = [];
+		for (let d = 0; d < 7; d++) {
+			const iso = cursor.toISOString().slice(0, 10);
+			days.push({ date: iso, count: 0, level: 0 as const });
+			cursor.setDate(cursor.getDate() + 1);
+		}
+		weeks.push({ days });
+	}
+	return weeks;
+}
+
+describe('computeMonthLabels', () => {
+	it('labels each month at the week where it first appears', () => {
+		// Start on a Sunday; 9 weeks spans Jan into March.
+		const weeks = weeksFrom('2024-01-07', 9);
+		const labels = computeMonthLabels(weeks);
+		expect(labels.map((l) => l.label)).toEqual(['Jan', 'Feb', 'Mar']);
+		// Columns are 1-indexed and strictly increasing.
+		const cols = labels.map((l) => l.col);
+		expect(cols).toEqual([...cols].sort((a, b) => a - b));
+		expect(cols[0]).toBe(1);
+	});
+
+	it('skips a label that would collide with the previous one', () => {
+		// A month boundary lands 2 columns after Jan (< default minGap of 3):
+		// the colliding month is consumed but no label is emitted for it.
+		const weeks = weeksFrom('2024-01-28', 6); // Jan 28 → into Feb quickly, then Mar
+		const labels = computeMonthLabels(weeks, 3);
+		const cols = labels.map((l) => l.col);
+		for (let i = 1; i < cols.length; i++) {
+			expect(cols[i] - cols[i - 1]).toBeGreaterThanOrEqual(3);
+		}
+	});
+
+	it('respects a custom minimum gap', () => {
+		const weeks = weeksFrom('2024-01-07', 20);
+		const tight = computeMonthLabels(weeks, 1);
+		const loose = computeMonthLabels(weeks, 6);
+		expect(loose.length).toBeLessThanOrEqual(tight.length);
+	});
+
+	it('ignores empty weeks and returns nothing for no data', () => {
+		expect(computeMonthLabels([])).toEqual([]);
+		expect(computeMonthLabels([{ days: [] }, { days: [] }])).toEqual([]);
+	});
+
+	it('produces roughly one label per month across a trailing year', () => {
+		const weeks = weeksFrom('2024-01-07', 53);
+		const labels = computeMonthLabels(weeks);
+		// 12–13 months of coverage; every label is a valid 3-letter month.
+		expect(labels.length).toBeGreaterThanOrEqual(11);
+		expect(labels.length).toBeLessThanOrEqual(13);
+		for (const l of labels) {
+			expect(l.label).toMatch(/^[A-Z][a-z]{2}$/);
+		}
+	});
+});
+
+describe('weekdayRow', () => {
+	it('maps Sunday…Saturday to rows 1…7', () => {
+		expect(weekdayRow('2024-01-07')).toBe(1); // Sunday
+		expect(weekdayRow('2024-01-08')).toBe(2); // Monday
+		expect(weekdayRow('2024-01-13')).toBe(7); // Saturday
+	});
+});
+
+describe('dayTooltip', () => {
+	it('singularises a single contribution', () => {
+		expect(dayTooltip({ date: '2024-03-01', count: 1, level: 1 })).toBe(
+			'1 contribution on Mar 1, 2024'
+		);
+	});
+
+	it('pluralises zero and many contributions', () => {
+		expect(dayTooltip({ date: '2024-03-02', count: 0, level: 0 })).toBe(
+			'0 contributions on Mar 2, 2024'
+		);
+		expect(dayTooltip({ date: '2024-12-25', count: 7, level: 4 })).toBe(
+			'7 contributions on Dec 25, 2024'
+		);
+	});
+});

--- a/frontend/src/lib/site/utils/githubContributions.ts
+++ b/frontend/src/lib/site/utils/githubContributions.ts
@@ -1,0 +1,67 @@
+/**
+ * Helpers for the GitHub contributions heatmap
+ */
+
+export interface ContributionDay {
+	date: string;
+	count: number;
+	level: 0 | 1 | 2 | 3 | 4;
+}
+
+export interface ContributionWeek {
+	days: ContributionDay[];
+}
+
+export interface MonthLabel {
+	/** 1-indexed grid column (week) where the label sits. */
+	col: number;
+	label: string;
+}
+
+/** Parse a `YYYY-MM-DD` date as local midnight (avoids UTC off-by-one). */
+function localDate(date: string): Date {
+	return new Date(`${date}T00:00:00`);
+}
+
+/**
+ * One month label per month, positioned at the week column where it first appears.
+ */
+export function computeMonthLabels(weeks: ContributionWeek[], minGap = 3): MonthLabel[] {
+	const labels: MonthLabel[] = [];
+	let lastMonth = -1;
+	let lastCol = -minGap;
+
+	weeks.forEach((week, i) => {
+		const first = week.days[0];
+		if (!first) return;
+		const month = localDate(first.date).getMonth();
+		if (month === lastMonth) return;
+
+		if (i - lastCol >= minGap) {
+			labels.push({
+				col: i + 1,
+				label: localDate(first.date).toLocaleString('en-US', { month: 'short' })
+			});
+			lastCol = i;
+		}
+		lastMonth = month;
+	});
+
+	return labels;
+}
+
+/** Grid row (1…7) for a date's weekday, Sunday = 1. */
+export function weekdayRow(date: string): number {
+	return localDate(date).getDay() + 1;
+}
+
+/** Native-tooltip text for a single day cell. */
+export function dayTooltip(day: ContributionDay): string {
+	const label = day.count === 1 ? '1 contribution' : `${day.count} contributions`;
+	const when = localDate(day.date).toLocaleDateString('en-US', {
+		month: 'short',
+		day: 'numeric',
+		year: 'numeric'
+	});
+	return `${label} on ${when}`;
+}

--- a/frontend/src/routes/(admin)/admin/configuration/+layout.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/+layout.svelte
@@ -437,7 +437,8 @@
 
 	.settings-page-content {
 		padding: 0;
-		max-width: 1200px;
+		/* Config-page content width */
+		max-width: 1000px;
 		margin: 0 auto;
 		width: 100%;
 		min-width: 0;

--- a/frontend/src/routes/(admin)/admin/configuration/+layout.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/+layout.svelte
@@ -20,7 +20,8 @@
 		Mail,
 		Palette,
 		Bell,
-		Megaphone
+		Megaphone,
+		Github
 	} from 'lucide-svelte';
 
 	let { children } = $props();
@@ -144,6 +145,18 @@
 			borderColor: 'rgba(59, 130, 246, 0.2)',
 			iconBgColor: '#60a5fa', // Light blue
 			path: '/admin/configuration/twitter',
+			section: 'home'
+		},
+		{
+			id: 'github',
+			title: 'GitHub Activity',
+			description: 'Show a GitHub contributions heatmap on the homepage',
+			icon: Github,
+			color: 'from-gray-500 to-gray-700',
+			bgColor: 'rgba(148, 163, 184, 0.1)',
+			borderColor: 'rgba(148, 163, 184, 0.2)',
+			iconBgColor: '#94a3b8', // Slate
+			path: '/admin/configuration/github',
 			section: 'home'
 		},
 		{
@@ -302,6 +315,8 @@
 						<Mail size={18} />
 					{:else if selectedCategory.icon === Megaphone}
 						<Megaphone size={18} />
+					{:else if selectedCategory.icon === Github}
+						<Github size={18} />
 					{/if}
 					{selectedCategory.title}
 				</h1>

--- a/frontend/src/routes/(admin)/admin/configuration/advertisement/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/advertisement/+page.svelte
@@ -611,10 +611,11 @@
 {/snippet}
 
 <div class="advert-config">
-	<p class="page-description">
-		Manage the image-only advertisement banner shown in the homepage right column, between Recent
-		posts and Systems status. Add multiple adverts and the banner rotates between them.
-	</p>
+	<div class="settings-description">
+		<p>
+			Manage the image-only advertisement banner shown on the homepage. Add multiple adverts and the banner rotates between them.
+		</p>
+	</div>
 
 	<div class="config-form">
 		<!-- Enabled Toggle -->
@@ -790,17 +791,24 @@
 
 <style>
 	.advert-config {
-		padding: 24px;
+		width: 100%;
+		max-width: 800px;
 		min-width: 0;
 		box-sizing: border-box;
 		overflow-x: hidden;
 	}
 
-	.page-description {
+	.settings-description {
+		margin-bottom: 24px;
+		padding-bottom: 16px;
+		border-bottom: 1px solid var(--border-color, #3a3a3a);
+	}
+
+	.settings-description p {
 		color: var(--text-secondary, #a1a1aa);
+		margin: 0;
 		font-size: 14px;
-		margin: 0 0 24px 0;
-		max-width: 60ch;
+		line-height: 1.5;
 	}
 
 	.config-form {
@@ -1247,12 +1255,6 @@
 	.cancel-btn:disabled {
 		opacity: 0.6;
 		cursor: not-allowed;
-	}
-
-	@media (max-width: 768px) {
-		.advert-config {
-			padding: 16px;
-		}
 	}
 
 	@media (max-width: 480px) {

--- a/frontend/src/routes/(admin)/admin/configuration/advertisement/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/advertisement/+page.svelte
@@ -613,7 +613,8 @@
 <div class="advert-config">
 	<div class="settings-description">
 		<p>
-			Manage the image-only advertisement banner shown on the homepage. Add multiple adverts and the banner rotates between them.
+			Manage the image-only advertisement banner shown on the homepage. Add multiple adverts and the
+			banner rotates between them.
 		</p>
 	</div>
 
@@ -792,7 +793,6 @@
 <style>
 	.advert-config {
 		width: 100%;
-		max-width: 800px;
 		min-width: 0;
 		box-sizing: border-box;
 		overflow-x: hidden;

--- a/frontend/src/routes/(admin)/admin/configuration/banner/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/banner/+page.svelte
@@ -79,6 +79,10 @@
 </svelte:head>
 
 <div class="banner-config">
+	<div class="settings-description">
+		<p>Configure the scrolling text banner shown across the top of the homepage.</p>
+	</div>
+
 	{#if loading}
 		<div class="loading-state">
 			<div class="spinner"></div>
@@ -245,10 +249,23 @@
 
 <style>
 	.banner-config {
-		padding: 24px;
+		width: 100%;
 		min-width: 0;
 		box-sizing: border-box;
 		overflow-x: hidden;
+	}
+
+	.settings-description {
+		margin-bottom: 24px;
+		padding-bottom: 16px;
+		border-bottom: 1px solid var(--border-color, #3a3a3a);
+	}
+
+	.settings-description p {
+		color: var(--text-secondary, #a1a1aa);
+		margin: 0;
+		font-size: 14px;
+		line-height: 1.5;
 	}
 
 	.loading-state {
@@ -549,12 +566,6 @@
 	.save-button:disabled {
 		opacity: 0.6;
 		cursor: not-allowed;
-	}
-
-	@media (max-width: 768px) {
-		.banner-config {
-			padding: 16px;
-		}
 	}
 
 	@media (max-width: 480px) {

--- a/frontend/src/routes/(admin)/admin/configuration/biography/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/biography/+page.svelte
@@ -115,7 +115,6 @@ This is my personal website where I showcase some of the side projects I'm worki
 <style>
 	.biography-settings {
 		width: 100%;
-		max-width: 1000px;
 	}
 
 	.settings-description {

--- a/frontend/src/routes/(admin)/admin/configuration/certifications/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/certifications/+page.svelte
@@ -822,7 +822,6 @@
 <style>
 	.certifications-settings {
 		width: 100%;
-		max-width: 800px;
 	}
 
 	.settings-description {

--- a/frontend/src/routes/(admin)/admin/configuration/contact-emails/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/contact-emails/+page.svelte
@@ -545,7 +545,6 @@
 <style>
 	.contact-emails-page {
 		width: 100%;
-		max-width: 800px;
 		min-width: 0;
 		box-sizing: border-box;
 	}

--- a/frontend/src/routes/(admin)/admin/configuration/contact-social-links/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/contact-social-links/+page.svelte
@@ -440,7 +440,9 @@
 											{:else if link.iconType === 'svg-inline' && link.svgInline}
 												{@const cfgSvgUnsel = sanitizeSvgInlineMarkup(link.svgInline)}
 												{#if cfgSvgUnsel}
-													<span class="svg-inline-thumb" aria-hidden="true">{@html cfgSvgUnsel}</span>
+													<span class="svg-inline-thumb" aria-hidden="true"
+														>{@html cfgSvgUnsel}</span
+													>
 												{:else}
 													<Link2 size={20} />
 												{/if}
@@ -494,7 +496,6 @@
 <style>
 	.contact-social-links-settings {
 		width: 100%;
-		max-width: 1000px;
 		min-width: 0;
 		box-sizing: border-box;
 	}

--- a/frontend/src/routes/(admin)/admin/configuration/contact-tagline/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/contact-tagline/+page.svelte
@@ -114,7 +114,6 @@
 <style>
 	.contact-tagline-settings {
 		width: 100%;
-		max-width: 1000px;
 	}
 
 	.settings-description {

--- a/frontend/src/routes/(admin)/admin/configuration/github/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/github/+page.svelte
@@ -1,0 +1,681 @@
+<script lang="ts">
+	import { logger } from '$lib/logger';
+	import { adminPageTitle } from '$lib/site/pageTitle';
+
+	import { onMount } from 'svelte';
+	import { get } from 'svelte/store';
+	import { Save, Eye, EyeOff, CheckCircle2, XCircle, RefreshCw, Edit2 } from 'lucide-svelte';
+	import { siteConfig, loadSiteConfig } from '$lib/site/stores/siteConfig';
+	import { toast } from 'svelte-sonner';
+	import { notifySiteConfigConsumers } from '$lib/shared/utils/siteConfigLiveSync';
+	import Toggle from '$lib/admin/components/ui/Toggle.svelte';
+	import GitHubContributionsWidget from '$lib/site/components/widgets/GitHubContributionsWidget.svelte';
+
+	let enabled = $state(false);
+	let savedEnabled = $state(false);
+	let isSaving = $state(false);
+
+	interface GitHubStatus {
+		tokenConfigured: boolean;
+		username: string;
+		usernameSource: 'database' | 'environment';
+		connection: { connected: boolean; login?: string; message: string };
+	}
+
+	let status = $state<GitHubStatus | null>(null);
+	let statusLoading = $state(true);
+
+	// Inline username editing (lives in the status card).
+	let editingUsername = $state(false);
+	let usernameInput = $state('');
+	let savingUsername = $state(false);
+
+	async function loadStatus() {
+		statusLoading = true;
+		try {
+			const response = await fetch(`/api/github/status?ts=${Date.now()}`, {
+				credentials: 'include',
+				cache: 'no-store'
+			});
+			if (!response.ok) throw new Error(`HTTP ${response.status}`);
+			status = (await response.json()) as GitHubStatus;
+		} catch (e) {
+			logger.error('Error loading GitHub status:', e);
+			status = null;
+		} finally {
+			statusLoading = false;
+		}
+	}
+
+	const dirty = $derived(enabled !== savedEnabled);
+
+	function syncFromConfig(c: import('$lib/site/stores/siteConfig').SiteConfig) {
+		savedEnabled = Boolean(c.github_enabled);
+		enabled = savedEnabled;
+	}
+
+	function startEditingUsername() {
+		usernameInput = status?.username ?? '';
+		editingUsername = true;
+	}
+
+	function cancelEditingUsername() {
+		editingUsername = false;
+	}
+
+	async function saveUsername() {
+		savingUsername = true;
+		try {
+			await putConfig('github_username', usernameInput.trim(), 'string');
+			await loadSiteConfig();
+			notifySiteConfigConsumers();
+			editingUsername = false;
+			await loadStatus();
+			toast.success('GitHub username saved');
+		} catch (e) {
+			logger.error(e);
+			toast.error('Failed to save username', {
+				description: e instanceof Error ? e.message : 'Try again'
+			});
+		} finally {
+			savingUsername = false;
+		}
+	}
+
+	onMount(() => {
+		const unsub = siteConfig.subscribe(syncFromConfig);
+		loadStatus();
+		return unsub;
+	});
+
+	async function putConfig(key: string, value: unknown, dataType: string) {
+		const response = await fetch(`/api/config/${key}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			credentials: 'include',
+			body: JSON.stringify({ value, dataType })
+		});
+		if (!response.ok) {
+			const data = await response.json().catch(() => ({}));
+			throw new Error(data.error || `Failed to update ${key}`);
+		}
+	}
+
+	async function saveSettings() {
+		if (!dirty) return;
+		isSaving = true;
+		try {
+			await putConfig('github_enabled', enabled, 'boolean');
+			await loadSiteConfig();
+			notifySiteConfigConsumers();
+			syncFromConfig(get(siteConfig));
+			toast.success('GitHub settings saved');
+		} catch (e) {
+			logger.error(e);
+			toast.error('Failed to save settings', {
+				description: e instanceof Error ? e.message : 'Try again'
+			});
+		} finally {
+			isSaving = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{adminPageTitle('GitHub')}</title>
+</svelte:head>
+
+<div class="github-config">
+	<p class="page-description">
+		Show a GitHub contributions heatmap (the trailing year of commit activity) in the homepage right
+		column. Requires a <code>GITHUB_TOKEN</code> environment variable on the backend — any token with
+		default scopes can read public contributions.
+	</p>
+
+	<div class="status-card">
+		<div class="status-header">
+			<span class="status-title">Integration status</span>
+			<button
+				type="button"
+				class="refresh-btn"
+				onclick={loadStatus}
+				disabled={statusLoading}
+				aria-label="Refresh status"
+			>
+				<RefreshCw size={15} class={statusLoading ? 'spinning' : ''} />
+			</button>
+		</div>
+
+		<div class="status-row">
+			<span class="status-label">Username:</span>
+			{#if editingUsername}
+				<div class="username-edit">
+					<input
+						type="text"
+						bind:value={usernameInput}
+						placeholder="GitHub username"
+						class="username-input"
+						disabled={savingUsername}
+						onkeydown={(e) => {
+							if (e.key === 'Enter') saveUsername();
+							else if (e.key === 'Escape') cancelEditingUsername();
+						}}
+					/>
+					<div class="username-edit-actions">
+						<button
+							type="button"
+							class="icon-button"
+							onclick={saveUsername}
+							disabled={savingUsername}
+							title="Save"
+						>
+							<CheckCircle2 size={16} />
+						</button>
+						<button
+							type="button"
+							class="icon-button"
+							onclick={cancelEditingUsername}
+							disabled={savingUsername}
+							title="Cancel"
+						>
+							<XCircle size={16} />
+						</button>
+					</div>
+				</div>
+			{:else}
+				<div class="username-display">
+					<span class="status-value">{status?.username || 'Not set'}</span>
+					{#if status}
+						<span
+							class="username-source"
+							class:database={status.usernameSource === 'database'}
+							class:environment={status.usernameSource === 'environment'}
+						>
+							({status.usernameSource === 'database' ? 'Database' : 'Environment'})
+						</span>
+					{/if}
+					<button
+						type="button"
+						class="icon-button small"
+						onclick={startEditingUsername}
+						title="Edit username"
+					>
+						<Edit2 size={14} />
+					</button>
+				</div>
+			{/if}
+		</div>
+
+		<div class="status-row">
+			<span class="status-label">Token:</span>
+			{#if statusLoading && !status}
+				<span class="status-value muted">Checking…</span>
+			{:else if status?.tokenConfigured}
+				<span class="status-value ok">Configured</span>
+			{:else}
+				<span class="status-value bad">Not configured</span>
+			{/if}
+		</div>
+
+		<div class="status-row connection-row">
+			<span class="status-label">Connection:</span>
+			{#if statusLoading && !status}
+				<div class="connection-badge muted">
+					<span>Checking…</span>
+				</div>
+			{:else if status?.connection}
+				<div
+					class="connection-badge"
+					class:connected={status.connection.connected}
+					class:disconnected={!status.connection.connected}
+				>
+					{#if status.connection.connected}
+						<CheckCircle2 size={16} />
+					{:else}
+						<XCircle size={16} />
+					{/if}
+					<span class="connection-text">
+						{status.connection.connected ? 'Connected' : 'Disconnected'}
+					</span>
+					<span class="connection-message">{status.connection.message}</span>
+				</div>
+			{:else}
+				<div class="connection-badge disconnected">
+					<XCircle size={16} />
+					<span class="connection-text">Unavailable</span>
+					<span class="connection-message">Could not reach the status endpoint</span>
+				</div>
+			{/if}
+		</div>
+
+		<p class="status-note">
+			The token is read from the <code>GITHUB_TOKEN</code> environment variable. To change it, update
+			your environment and restart the server.
+		</p>
+	</div>
+
+	<div class="config-form">
+		<div class="form-group">
+			<div class="enabled-toggle">
+				<div class="toggle-with-icon">
+					<Toggle bind:checked={enabled} />
+					<span class="toggle-text">
+						{#if enabled}
+							<Eye size={16} />
+							GitHub Widget Enabled
+						{:else}
+							<EyeOff size={16} />
+							GitHub Widget Disabled
+						{/if}
+					</span>
+				</div>
+				<p class="help-text">Controls whether the contributions widget is shown on the site.</p>
+			</div>
+		</div>
+
+		<div class="form-actions">
+			<button class="save-button" onclick={saveSettings} disabled={!dirty || isSaving}>
+				<Save size={18} />
+				{isSaving ? 'Saving...' : 'Save Settings'}
+			</button>
+		</div>
+	</div>
+
+	<div class="preview-section">
+		<h2 class="preview-title">Preview</h2>
+		<p class="help-text">
+			The contribution chart for the configured account (shown here regardless of the enabled toggle
+			above).
+		</p>
+		<div class="preview-frame">
+			{#key status?.username}
+				<GitHubContributionsWidget />
+			{/key}
+		</div>
+	</div>
+</div>
+
+<style>
+	.github-config {
+		padding: 24px;
+		min-width: 0;
+		box-sizing: border-box;
+		overflow-x: hidden;
+	}
+
+	.page-description {
+		color: var(--text-secondary, #a1a1aa);
+		font-size: 14px;
+		margin: 0 0 24px 0;
+		max-width: 60ch;
+		line-height: 1.5;
+	}
+
+	.page-description code {
+		font-family: monospace;
+		font-size: 13px;
+		background: var(--bg-tertiary, #2d2d2d);
+		padding: 1px 5px;
+		border-radius: 4px;
+	}
+
+	.status-card {
+		display: flex;
+		flex-direction: column;
+		gap: 14px;
+		padding: 18px 20px;
+		margin-bottom: 24px;
+		background: var(--bg-secondary, #2a2a2a);
+		border: 1px solid var(--border-color, #3a3a3a);
+		border-radius: 12px;
+	}
+
+	.status-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.status-title {
+		font-size: 14px;
+		font-weight: 600;
+		color: var(--text-primary, #ffffff);
+	}
+
+	.refresh-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 30px;
+		height: 30px;
+		padding: 0;
+		border: 1px solid var(--border-color, #3a3a3a);
+		border-radius: 6px;
+		background: transparent;
+		color: var(--text-secondary, #a1a1aa);
+		cursor: pointer;
+		transition:
+			border-color 0.2s,
+			color 0.2s;
+	}
+
+	.refresh-btn:hover:not(:disabled) {
+		border-color: var(--accent-color, #6366f1);
+		color: var(--text-primary, #ffffff);
+	}
+
+	.refresh-btn:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.refresh-btn :global(.spinning) {
+		animation: gh-spin 0.9s linear infinite;
+	}
+
+	@keyframes gh-spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	.status-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		padding-bottom: 12px;
+		border-bottom: 1px solid var(--border-color, #3a3a3a);
+	}
+
+	.connection-row {
+		flex-direction: column;
+		align-items: stretch;
+		gap: 8px;
+	}
+
+	.status-label {
+		font-size: 14px;
+		font-weight: 500;
+		color: var(--text-primary, #ffffff);
+		flex-shrink: 0;
+	}
+
+	.status-value {
+		font-size: 14px;
+	}
+
+	.status-value.ok {
+		color: #10b981;
+	}
+
+	.status-value.bad {
+		color: #ef4444;
+	}
+
+	.status-value.muted {
+		color: var(--text-secondary, #a1a1aa);
+	}
+
+	.username-display {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex: 1;
+		min-width: 0;
+		flex-wrap: wrap;
+		justify-content: flex-end;
+	}
+
+	.username-source {
+		font-size: 12px;
+		padding: 2px 6px;
+		border-radius: 4px;
+		font-weight: 500;
+	}
+
+	.username-source.database {
+		background: var(--accent-muted-bg, var(--accent-color-light, rgba(99, 102, 241, 0.2)));
+		color: var(--accent-muted-fg, var(--accent-color, #6366f1));
+	}
+
+	.username-source.environment {
+		background: rgba(156, 163, 175, 0.2);
+		color: #9ca3af;
+	}
+
+	.icon-button {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 30px;
+		height: 30px;
+		padding: 0;
+		border: 1px solid var(--border-color, #3a3a3a);
+		border-radius: 6px;
+		background: transparent;
+		color: var(--text-secondary, #a1a1aa);
+		cursor: pointer;
+		transition:
+			border-color 0.2s,
+			color 0.2s;
+	}
+
+	.icon-button.small {
+		width: 26px;
+		height: 26px;
+	}
+
+	.icon-button:hover:not(:disabled) {
+		border-color: var(--accent-color, #6366f1);
+		color: var(--text-primary, #ffffff);
+	}
+
+	.icon-button:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.username-edit {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex: 1;
+		min-width: 0;
+		justify-content: flex-end;
+		flex-wrap: wrap;
+	}
+
+	.username-input {
+		flex: 1;
+		min-width: 140px;
+		background: var(--bg-tertiary, #2d2d2d);
+		border: 1px solid var(--border-color, #3a3a3a);
+		border-radius: 6px;
+		padding: 8px 12px;
+		color: var(--text-primary, #ffffff);
+		font-size: 14px;
+	}
+
+	.username-input:focus {
+		outline: none;
+		border-color: var(--accent-color, #6366f1);
+	}
+
+	.username-edit-actions {
+		display: flex;
+		gap: 6px;
+	}
+
+	.connection-badge {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px 12px;
+		border-radius: 6px;
+		font-size: 14px;
+		flex: 1;
+		min-width: 0;
+		flex-wrap: wrap;
+		box-sizing: border-box;
+	}
+
+	.connection-badge.connected {
+		background: rgba(16, 185, 129, 0.1);
+		border: 1px solid rgba(16, 185, 129, 0.3);
+		color: #10b981;
+	}
+
+	.connection-badge.disconnected {
+		background: rgba(239, 68, 68, 0.1);
+		border: 1px solid rgba(239, 68, 68, 0.3);
+		color: #ef4444;
+	}
+
+	.connection-badge.muted {
+		border: 1px solid var(--border-color, #3a3a3a);
+		color: var(--text-secondary, #a1a1aa);
+	}
+
+	.connection-text {
+		font-weight: 500;
+	}
+
+	.connection-message {
+		font-size: 12px;
+		opacity: 0.85;
+		margin-left: auto;
+		min-width: 0;
+		overflow-wrap: anywhere;
+	}
+
+	.status-note {
+		margin: 0;
+		font-size: 12px;
+		color: var(--text-secondary, #a1a1aa);
+		line-height: 1.5;
+	}
+
+	.status-note code {
+		font-family: monospace;
+		font-size: 12px;
+		background: var(--bg-tertiary, #2d2d2d);
+		padding: 1px 5px;
+		border-radius: 4px;
+	}
+
+	@media (max-width: 520px) {
+		.connection-message {
+			margin-left: 0;
+			flex-basis: 100%;
+		}
+	}
+
+	.config-form {
+		display: flex;
+		flex-direction: column;
+		gap: 24px;
+	}
+
+	.form-group {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.help-text {
+		color: var(--text-secondary, #a1a1aa);
+		font-size: 12px;
+		margin: 0;
+	}
+
+	.enabled-toggle {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.toggle-with-icon {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		padding: 12px;
+		background: var(--bg-tertiary, #2d2d2d);
+		border: 1px solid var(--border-color, #3a3a3a);
+		border-radius: 8px;
+		transition: all 0.2s ease;
+	}
+
+	.toggle-with-icon:hover {
+		border-color: var(--accent-color, #6366f1);
+	}
+
+	.toggle-text {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		color: var(--text-primary, #ffffff);
+		font-size: 14px;
+	}
+
+	.form-actions {
+		display: flex;
+		justify-content: flex-end;
+		padding-top: 8px;
+	}
+
+	.preview-section {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		margin-top: 32px;
+		padding-top: 24px;
+		border-top: 1px solid var(--border-color, #3a3a3a);
+	}
+
+	.preview-title {
+		margin: 0;
+		font-size: 16px;
+		font-weight: 600;
+		color: var(--text-primary, #ffffff);
+	}
+
+	.preview-frame {
+		margin-top: 8px;
+		padding: 12px 16px;
+		background: var(--bg-secondary, #2a2a2a);
+		border: 1px solid var(--border-color, #3a3a3a);
+		border-radius: 12px;
+	}
+
+	.save-button {
+		background: var(--accent-bg, var(--accent-color, #6366f1));
+		color: var(--accent-fg);
+		border: none;
+		border-radius: 8px;
+		padding: 12px 20px;
+		font-size: 14px;
+		font-weight: 500;
+		cursor: pointer;
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+		transition: all 0.2s ease;
+	}
+
+	.save-button:hover:not(:disabled) {
+		background: var(--accent-hover, #5b5bf6);
+		transform: translateY(-1px);
+	}
+
+	.save-button:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	@media (max-width: 768px) {
+		.github-config {
+			padding: 16px;
+		}
+	}
+</style>

--- a/frontend/src/routes/(admin)/admin/configuration/github/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/github/+page.svelte
@@ -646,6 +646,10 @@
 		background: var(--bg-secondary, #2a2a2a);
 		border: 1px solid var(--border-color, #3a3a3a);
 		border-radius: 12px;
+
+		--theme-accent: var(--accent-color, #6366f1);
+		--theme-surface: var(--bg-secondary, #2a2a2a);
+		--theme-text-primary: var(--text-primary, #ffffff);
 	}
 
 	.save-button {

--- a/frontend/src/routes/(admin)/admin/configuration/github/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/github/+page.svelte
@@ -128,7 +128,8 @@
 <div class="github-config">
 	<div class="settings-description">
 		<p>
-			Show a GitHub contributions heatmap in the homepage - Requires a <code>GITHUB_TOKEN</code> environment variable on the backend
+			Show a GitHub contributions heatmap in the homepage - Requires a <code>GITHUB_TOKEN</code> environment
+			variable on the backend
 		</p>
 	</div>
 
@@ -298,7 +299,6 @@
 <style>
 	.github-config {
 		width: 100%;
-		max-width: 800px;
 		min-width: 0;
 		box-sizing: border-box;
 		overflow-x: hidden;

--- a/frontend/src/routes/(admin)/admin/configuration/github/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/github/+page.svelte
@@ -126,11 +126,11 @@
 </svelte:head>
 
 <div class="github-config">
-	<p class="page-description">
-		Show a GitHub contributions heatmap (the trailing year of commit activity) in the homepage right
-		column. Requires a <code>GITHUB_TOKEN</code> environment variable on the backend — any token with
-		default scopes can read public contributions.
-	</p>
+	<div class="settings-description">
+		<p>
+			Show a GitHub contributions heatmap in the homepage - Requires a <code>GITHUB_TOKEN</code> environment variable on the backend
+		</p>
+	</div>
 
 	<div class="status-card">
 		<div class="status-header">
@@ -297,21 +297,27 @@
 
 <style>
 	.github-config {
-		padding: 24px;
+		width: 100%;
+		max-width: 800px;
 		min-width: 0;
 		box-sizing: border-box;
 		overflow-x: hidden;
 	}
 
-	.page-description {
+	.settings-description {
+		margin-bottom: 24px;
+		padding-bottom: 16px;
+		border-bottom: 1px solid var(--border-color, #3a3a3a);
+	}
+
+	.settings-description p {
 		color: var(--text-secondary, #a1a1aa);
+		margin: 0;
 		font-size: 14px;
-		margin: 0 0 24px 0;
-		max-width: 60ch;
 		line-height: 1.5;
 	}
 
-	.page-description code {
+	.settings-description code {
 		font-family: monospace;
 		font-size: 13px;
 		background: var(--bg-tertiary, #2d2d2d);
@@ -675,11 +681,5 @@
 	.save-button:disabled {
 		opacity: 0.6;
 		cursor: not-allowed;
-	}
-
-	@media (max-width: 768px) {
-		.github-config {
-			padding: 16px;
-		}
 	}
 </style>

--- a/frontend/src/routes/(admin)/admin/configuration/homepage-about/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/homepage-about/+page.svelte
@@ -118,7 +118,6 @@
 <style>
 	.homepage-about-settings {
 		width: 100%;
-		max-width: 1000px;
 	}
 
 	.settings-description {

--- a/frontend/src/routes/(admin)/admin/configuration/neko/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/neko/+page.svelte
@@ -4,7 +4,7 @@
 
 	import { onMount } from 'svelte';
 	import { get } from 'svelte/store';
-	import { Cat, Lock, Save, Loader2 } from 'lucide-svelte';
+	import { Lock, Save, Loader2 } from 'lucide-svelte';
 	import { siteConfig, loadSiteConfig } from '$lib/site/stores/siteConfig';
 	import { toast } from 'svelte-sonner';
 	import { notifySiteConfigConsumers } from '$lib/shared/utils/siteConfigLiveSync';
@@ -145,17 +145,13 @@
 </svelte:head>
 
 <div class="neko-admin">
-	<div class="page-head">
-		<Cat size={22} class="neko-page-icon" aria-hidden="true" />
-		<div>
-			<h2 class="page-title">Web Neko</h2>
-			<p class="page-desc">
-				Art and script from <a href="https://webneko.net/" target="_blank" rel="noopener noreferrer"
-					>webneko.net</a
-				>. Optional site-wide lock is below; further down, set the default for new visitors and for
-				anyone without a saved choice while the lock is off.
-			</p>
-		</div>
+	<div class="settings-description">
+		<p>
+			Web Neko follows the cursor around the site. Art and script from
+			<a href="https://webneko.net/" target="_blank" rel="noopener noreferrer">webneko.net</a>.
+			Optional site-wide lock is below; further down, set the default for new visitors and for
+			anyone without a saved choice while the lock is off.
+		</p>
 	</div>
 
 	<section class="neko-enforcement-panel" aria-labelledby="neko-enforcement-heading">
@@ -284,36 +280,20 @@
 		box-sizing: border-box;
 	}
 
-	.page-head {
-		display: flex;
-		align-items: flex-start;
-		gap: 14px;
+	.settings-description {
 		margin-bottom: 24px;
 		padding-bottom: 16px;
 		border-bottom: 1px solid var(--border-color, #3a3a3a);
 	}
 
-	:global(.neko-page-icon) {
-		flex-shrink: 0;
-		color: var(--accent-on-surface, var(--accent-color, #6366f1));
-		margin-top: 2px;
-	}
-
-	.page-title {
-		margin: 0 0 6px 0;
-		font-size: 1.25rem;
-		font-weight: 600;
-		color: var(--text-primary, #fff);
-	}
-
-	.page-desc {
+	.settings-description p {
 		margin: 0;
-		font-size: 13px;
+		font-size: 14px;
 		line-height: 1.5;
 		color: var(--text-secondary, #a1a1aa);
 	}
 
-	.page-desc a {
+	.settings-description a {
 		color: var(--accent-on-surface, var(--accent-color, #6366f1));
 		text-decoration: underline;
 		text-underline-offset: 2px;

--- a/frontend/src/routes/(admin)/admin/configuration/notifications/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/notifications/+page.svelte
@@ -273,14 +273,18 @@
 						bind:appearance={settings.twitter.restored}
 						title="Connection restored"
 						description="Sent when the Twitter API connection recovers after a failure."
-						onedit={() =>
-							openEditor('Connection restored', settings!.twitter.restored, ['time'])}
+						onedit={() => openEditor('Connection restored', settings!.twitter.restored, ['time'])}
 					/>
 				</div>
 			</section>
 
 			<div class="form-actions">
-				<button type="button" class="secondary-button" onclick={resetToDefaults} disabled={!hasDefaults}>
+				<button
+					type="button"
+					class="secondary-button"
+					onclick={resetToDefaults}
+					disabled={!hasDefaults}
+				>
 					<RotateCcw size={16} />
 					Reset to defaults
 				</button>

--- a/frontend/src/routes/(admin)/admin/configuration/service-status/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/service-status/+page.svelte
@@ -303,6 +303,10 @@
 </svelte:head>
 
 <div class="service-status-config">
+	<div class="settings-description">
+		<p>Configure the homepage service status widget, powered by your Uptime Kuma monitors.</p>
+	</div>
+
 	{#if loading}
 		<div class="loading-state">
 			<div class="spinner"></div>
@@ -624,6 +628,19 @@
 <style>
 	.service-status-config {
 		padding: 0;
+	}
+
+	.settings-description {
+		margin-bottom: 24px;
+		padding-bottom: 16px;
+		border-bottom: 1px solid var(--border-color, #3a3a3a);
+	}
+
+	.settings-description p {
+		color: var(--text-secondary, #a1a1aa);
+		margin: 0;
+		font-size: 14px;
+		line-height: 1.5;
 	}
 
 	.loading-state {

--- a/frontend/src/routes/(admin)/admin/configuration/skills/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/skills/+page.svelte
@@ -786,7 +786,6 @@
 <style>
 	.skills-settings {
 		width: 100%;
-		max-width: 800px;
 		min-width: 0;
 		box-sizing: border-box;
 	}

--- a/frontend/src/routes/(admin)/admin/configuration/social-links/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/social-links/+page.svelte
@@ -844,7 +844,6 @@
 <style>
 	.social-links-page {
 		width: 100%;
-		max-width: 800px;
 		min-width: 0;
 		box-sizing: border-box;
 	}

--- a/frontend/src/routes/(admin)/admin/configuration/themes/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/themes/+page.svelte
@@ -920,9 +920,7 @@
 											Manage
 										</button>
 									</div>
-									<p class="form-hint">
-										Groups this theme in the public theme selector.
-									</p>
+									<p class="form-hint">Groups this theme in the public theme selector.</p>
 								</div>
 							</div>
 						</section>
@@ -2087,7 +2085,6 @@
 <style>
 	.themes-settings {
 		width: 100%;
-		max-width: 1200px;
 	}
 
 	.settings-description {

--- a/frontend/src/routes/(admin)/admin/configuration/twitter/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/configuration/twitter/+page.svelte
@@ -387,6 +387,10 @@
 </svelte:head>
 
 <div class="twitter-config">
+	<div class="settings-description">
+		<p>Manage the Twitter/X integration that powers the status widget on the homepage.</p>
+	</div>
+
 	{#if loading}
 		<div class="loading-state">
 			<div class="spinner"></div>
@@ -748,6 +752,19 @@
 		min-width: 0;
 		box-sizing: border-box;
 		overflow-x: hidden;
+	}
+
+	.settings-description {
+		margin-bottom: 24px;
+		padding-bottom: 16px;
+		border-bottom: 1px solid var(--border-color, #3a3a3a);
+	}
+
+	.settings-description p {
+		color: var(--text-secondary, #a1a1aa);
+		margin: 0;
+		font-size: 14px;
+		line-height: 1.5;
 	}
 
 	.loading-state,

--- a/frontend/src/routes/(site)/+page.svelte
+++ b/frontend/src/routes/(site)/+page.svelte
@@ -10,6 +10,7 @@
 	import BorderedBox from '$lib/site/components/ui/BorderedBox.svelte';
 	import ServiceStatus from '$lib/site/components/widgets/ServiceStatus.svelte';
 	import AdvertBanner from '$lib/site/components/widgets/AdvertBanner.svelte';
+	import GitHubContributionsWidget from '$lib/site/components/widgets/GitHubContributionsWidget.svelte';
 	import { siteConfig } from '$lib/site/stores/siteConfig';
 	import { adverts } from '$lib/site/stores/adverts';
 	import SiteStats from '$lib/site/components/widgets/SiteStats.svelte';
@@ -192,6 +193,23 @@
 						</div>
 					</BorderedBox>
 				</div>
+
+				{#if $siteConfig.github_enabled}
+					<div class="card-slot" data-mobile-order="13">
+						<BorderedBox
+							padding="8px 16px"
+							className="github-contributions-section"
+							showHeader={true}
+							headerText="github commits"
+							dynamicHeight={true}
+							contentPadding={true}
+						>
+							<LazyWhenVisible minHeight="160px">
+								<GitHubContributionsWidget />
+							</LazyWhenVisible>
+						</BorderedBox>
+					</div>
+				{/if}
 
 				{#if $siteConfig.advert_enabled && $adverts.length > 0}
 					<div class="card-slot advert-slot" data-mobile-order="5">
@@ -544,7 +562,6 @@
 		outline: none !important;
 	}
 
-
 	:global(.discord-widget),
 	:global(.tweet-widget),
 	:global(.music-widget),
@@ -717,6 +734,9 @@
 		}
 		.card-slot[data-mobile-order='12'] {
 			order: 12;
+		}
+		.card-slot[data-mobile-order='13'] {
+			order: 13;
 		}
 
 		:global(.discord-widget) {

--- a/frontend/src/routes/(site)/+page.svelte
+++ b/frontend/src/routes/(site)/+page.svelte
@@ -176,7 +176,7 @@
 						padding="8px 16px"
 						className="recent-posts-section"
 						showHeader={true}
-						headerText="Recent posts"
+						headerText="Recent Posts"
 						dynamicHeight={true}
 						contentPadding={true}
 					>
@@ -200,7 +200,7 @@
 							padding="8px 16px"
 							className="github-contributions-section"
 							showHeader={true}
-							headerText="github commits"
+							headerText="GitHub Activity"
 							dynamicHeight={true}
 							contentPadding={true}
 						>
@@ -227,7 +227,7 @@
 						padding="8px 16px"
 						className="service-status-section"
 						showHeader={true}
-						headerText="Systems status:"
+						headerText="Systems Status:"
 						subheading={overallStatus}
 						subheadingSemanticStatus={true}
 						dynamicHeight={true}


### PR DESCRIPTION
Adds a GitHub contributions heatmap widget to the homepage, themed to the site, with a full admin management page. Along the way, standardises the header style and content width across every site-settings page.