### PR TITLE
Fix GitHub heatmap scrolling for small screens

### DIFF
--- a/frontend/src/lib/site/components/widgets/GitHubContributionsWidget.svelte
+++ b/frontend/src/lib/site/components/widgets/GitHubContributionsWidget.svelte
@@ -100,6 +100,10 @@
 		padding: 4px 0 8px;
 		box-sizing: border-box;
 
+		/* Minimum cell width. Cells expand to fill the column (1fr) but never
+		   shrink below this */
+		--gh-cell-min: 10px;
+
 		/* Base ramp (grayscale) — works everywhere and is the fallback when
 		   color-mix() is unavailable. */
 		--gh-level-0: rgba(255, 255, 255, 0.06);
@@ -179,6 +183,14 @@
 		grid-template-columns: repeat(var(--weeks), 1fr);
 		grid-template-rows: repeat(7, auto);
 		gap: 2px;
+	}
+
+	/* On small screens, stop cells shrinking below a legible size */
+	@media (max-width: 768px) {
+		.gh-months,
+		.gh-grid {
+			grid-template-columns: repeat(var(--weeks), minmax(var(--gh-cell-min), 1fr));
+		}
 	}
 
 	.gh-cell {

--- a/frontend/src/routes/(site)/+page.svelte
+++ b/frontend/src/routes/(site)/+page.svelte
@@ -64,7 +64,7 @@
 					</BorderedBox>
 				</div>
 
-				<div class="card-slot" data-mobile-order="8">
+				<div class="card-slot" data-mobile-order="9">
 					<BorderedBox
 						padding="8px 16px"
 						className="tweet-widget tweet-bordered-box"
@@ -76,7 +76,7 @@
 					</BorderedBox>
 				</div>
 
-				<div class="card-slot" data-mobile-order="9">
+				<div class="card-slot" data-mobile-order="10">
 					<BorderedBox
 						padding="8px 16px"
 						className="music-widget"
@@ -111,13 +111,13 @@
 					</BorderedBox>
 				</div>
 
-				<div class="card-slot" data-mobile-order="10">
+				<div class="card-slot" data-mobile-order="11">
 					<LazyWhenVisible minHeight="72px">
 						<ButtonBanner />
 					</LazyWhenVisible>
 				</div>
 
-				<div class="card-slot" data-mobile-order="11">
+				<div class="card-slot" data-mobile-order="12">
 					<BorderedBox
 						padding="0 16px"
 						className="my-button-widget"
@@ -131,7 +131,7 @@
 					</BorderedBox>
 				</div>
 
-				<div class="card-slot" data-mobile-order="12">
+				<div class="card-slot" data-mobile-order="13">
 					<BorderedBox
 						padding="8px 16px"
 						className="site-stats-widget"
@@ -195,7 +195,7 @@
 				</div>
 
 				{#if $siteConfig.github_enabled}
-					<div class="card-slot" data-mobile-order="13">
+					<div class="card-slot" data-mobile-order="8">
 						<BorderedBox
 							padding="8px 16px"
 							className="github-contributions-section"


### PR DESCRIPTION
Two small homepage adjustments to the GitHub Activity widget:

1. **Mobile order** — move the GitHub Activity widget to sit between the Links
   and Status widgets in the mobile stacking order. The widgets that followed
   (Twitter/Status, Recently Played, 88×31 banner, My Button, Site Stats) each
   shift down by one. Desktop's two-column layout is unaffected — only the
   `@media (max-width: 768px)` `data-mobile-order` values changed, and the
   values remain a clean 1–13 sequence.

2. **Small-screen scaling** — the contribution heatmap became unreadably tiny on
   narrow screens because its `1fr` columns shrink without limit. On mobile
   (≤768px) the cells now have a `minmax(10px, 1fr)` floor, so once they'd get
   too small the chart overflows and scrolls horizontally instead. On larger
   screens the plain `1fr` columns still fill the column and never scroll (the
   minimum is intentionally gated behind the breakpoint so it doesn't force
   constant overflow in the desktop column). The `--gh-cell-min` variable tunes
   the threshold.